### PR TITLE
Add Spring milestone repository and update release notes generation

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -8,6 +8,9 @@
 
 name: Maven Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ 'dev-1.x' ]

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       max-parallel: 7
       matrix:
-        java: [ '8', '11' ]
+        java: [ '8', '11' , '17' , '21' , '25' ]
         maven-profile-spring-boot: [ 'spring-boot-2.1' , 'spring-boot-2.2' , 'spring-boot-2.3',
                                      'spring-boot-2.4' ,'spring-boot-2.5' , 'spring-boot-2.6' ,
                                      'spring-boot-2.7' ]

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -21,8 +21,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 7
       matrix:
-        java: [ '8', '11' , '17' , '21' , '25' ]
+        java: [ '8', '11' ]
         maven-profile-spring-boot: [ 'spring-boot-2.1' , 'spring-boot-2.2' , 'spring-boot-2.3',
                                      'spring-boot-2.4' ,'spring-boot-2.5' , 'spring-boot-2.6' ,
                                      'spring-boot-2.7' ]

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -21,6 +21,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ inputs.revision }}
     steps:
       - name: Validate version format
@@ -59,7 +61,6 @@ jobs:
           SIGN_KEY_ID: ${{ secrets.OSS_SIGNING_KEY_ID_LONG }}
           SIGN_KEY: ${{ secrets.OSS_SIGNING_KEY }}
           SIGN_KEY_PASS: ${{ secrets.OSS_SIGNING_PASSWORD }}
-
 
   release:
     runs-on: ubuntu-latest
@@ -119,8 +120,9 @@ jobs:
           prompt = (
               f"Generate concise release notes for version {current_tag}.\n\n"
               f"Commits since {prev_tag}:\n{commits}\n\n"
-              "Format the output as markdown with sections for New Features, Bug Fixes, "
-              "and Other Changes (only include sections that have relevant commits). "
+              "Format the output as markdown with sections if present for New Features, Bug Fixes, "
+              "Documentations, Dependency Updates, Test Improvements, Build and Workflow Enhancements "
+              "and Other Changes(excludes Full Changelog).\n\n"
               "Be concise and clear."
           )
 
@@ -153,20 +155,25 @@ jobs:
           if [ ! -f "$NOTES_FILE" ]; then
             printf "# Release Notes\n\n" > "$NOTES_FILE"
           fi
+          
+          FULL_CHANGELOG="**Full Changelog**: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/$PREV_TAG...$CURRENT_TAG"
+          
           printf "## v%s\n\n%s\n\n" "$CURRENT_TAG" "$SUMMARY" >> "$NOTES_FILE"
-
+          printf "%s" "$FULL_CHANGELOG" >> "$NOTES_FILE"
+          
           # Write the current release notes to a temp file for the Create Release step
-          printf "%s" "$SUMMARY" > /tmp/current-release-notes.md
+          printf "%s\n\n" "$SUMMARY" > /tmp/current-release-notes.md
+          printf "%s" "$FULL_CHANGELOG" >> /tmp/current-release-notes.md
 
           echo "Release notes generated and appended to $NOTES_FILE"
 
       - name: Create Release
         run: |
-          if gh release view "v${{ inputs.revision }}" >/dev/null 2>&1; then
-            echo "Release v${{ inputs.revision }} already exists, skipping."
+          if gh release view "${{ inputs.revision }}" >/dev/null 2>&1; then
+            echo "Release ${{ inputs.revision }} already exists, skipping."
           else
             gh release create ${{ inputs.revision }} \
-              --title "v${{ inputs.revision }}" \
+              --title "${{ inputs.revision }}" \
               --notes-file /tmp/current-release-notes.md \
               --latest
           fi

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -21,6 +21,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ inputs.revision }}
     steps:
       - name: Validate version format
@@ -66,6 +68,7 @@ jobs:
     needs: build
     permissions:
       contents: write
+      models: read
     steps:
       - name: Checkout Source
         uses: actions/checkout@v5
@@ -83,14 +86,90 @@ jobs:
             git push origin ${{ inputs.revision }}
           fi
 
+      - name: Generate Release Notes with Copilot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT_TAG="${{ inputs.revision }}"
+
+          # Find the previous tag (the one before the current tag)
+          PREV_TAG=$(git describe --tags --abbrev=0 --exclude="${CURRENT_TAG}" HEAD 2>/dev/null || echo "")
+
+          # Collect commits between the previous tag and HEAD
+          if [ -n "$PREV_TAG" ]; then
+            COMMITS=$(git log --oneline "${PREV_TAG}..HEAD" 2>/dev/null || echo "No commits found")
+            SINCE_LABEL="$PREV_TAG"
+          else
+            COMMITS=$(git log --oneline -50 2>/dev/null || echo "No commits found")
+            SINCE_LABEL="the beginning"
+          fi
+
+          # Export for Python (avoids shell-escaping issues with multiline content)
+          export CURRENT_TAG_DATA="$CURRENT_TAG"
+          export PREV_TAG_DATA="$SINCE_LABEL"
+          export COMMITS_DATA="$COMMITS"
+
+          # Call GitHub Copilot via GitHub Models API and capture the summary
+          SUMMARY=$(python3 << 'PYEOF'
+          import json, os, urllib.request, sys
+
+          current_tag = os.environ['CURRENT_TAG_DATA']
+          prev_tag    = os.environ['PREV_TAG_DATA']
+          commits     = os.environ['COMMITS_DATA']
+          token       = os.environ['GH_TOKEN']
+
+          prompt = (
+              f"Generate concise release notes for version {current_tag}.\n\n"
+              f"Commits since {prev_tag}:\n{commits}\n\n"
+              "Format the output as markdown with sections for New Features, Bug Fixes, "
+              "and Other Changes (only include sections that have relevant commits). "
+              "Be concise and clear."
+          )
+
+          payload = json.dumps({
+              "model": "gpt-4o",
+              "messages": [{"role": "user", "content": prompt}]
+          }).encode()
+
+          req = urllib.request.Request(
+              "https://models.inference.ai.azure.com/chat/completions",
+              data=payload,
+              headers={
+                  "Content-Type": "application/json",
+                  "Authorization": f"Bearer {token}"
+              }
+          )
+
+          try:
+              with urllib.request.urlopen(req) as resp:
+                  data = json.loads(resp.read())
+                  print(data["choices"][0]["message"]["content"])
+          except Exception as e:
+              print(f"Failed to generate summary via Copilot: {e}", file=sys.stderr)
+              print(f"_Release notes generation failed. Raw commits since {prev_tag}:_\n\n```\n{commits}\n```")
+          PYEOF
+          )
+
+          # Append the summary (with version header) to release-notes.md
+          NOTES_FILE="release-notes.md"
+          if [ ! -f "$NOTES_FILE" ]; then
+            printf "# Release Notes\n\n" > "$NOTES_FILE"
+          fi
+          printf "## v%s\n\n%s\n\n" "$CURRENT_TAG" "$SUMMARY" >> "$NOTES_FILE"
+
+          # Write the current release notes to a temp file for the Create Release step
+          printf "%s" "$SUMMARY" > /tmp/current-release-notes.md
+
+          echo "Release notes generated and appended to $NOTES_FILE"
+
       - name: Create Release
         run: |
           if gh release view "v${{ inputs.revision }}" >/dev/null 2>&1; then
             echo "Release v${{ inputs.revision }} already exists, skipping."
           else
-            gh release create v${{ inputs.revision }} \
+            gh release create ${{ inputs.revision }} \
               --title "v${{ inputs.revision }}" \
-              --generate-notes \
+              --notes-file /tmp/current-release-notes.md \
               --latest
           fi
         env:
@@ -111,7 +190,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pom.xml
+          git add pom.xml release-notes.md
           git diff --cached --quiet && echo "No changes to commit" || \
             git commit -m "chore: bump version to next patch after publishing ${{ inputs.revision }}" && git push
 

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -21,8 +21,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     if: ${{ inputs.revision }}
     steps:
       - name: Validate version format

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://maven.aliyun.com/repository/public/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://dlcdn.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.zip

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://maven.aliyun.com/repository/public/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://dlcdn.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.zip
+distributionUrl=https://maven.aliyun.com/repository/public/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 ![Maven](https://img.shields.io/maven-central/v/io.github.microsphere-projects/microsphere-spring-boot.svg)
 ![License](https://img.shields.io/github/license/microsphere-projects/microsphere-spring-boot.svg)
 
-
 Microsphere Spring Boot is a collection of libraries that extends Spring Boot's capabilities with additional features
 focused on configuration management, application diagnostics, and enhanced monitoring. The project is structured as a
 multi-module Maven project that follows Spring Boot's conventions while providing value-added functionality.
@@ -41,6 +40,7 @@ The easiest way to get started is by adding the Microsphere Spring Boot BOM (Bil
 pom.xml:
 
 ```xml
+
 <dependencyManagement>
     <dependencies>
         ...
@@ -61,12 +61,13 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **0.2.x**    | Compatible with Spring Boot 3.0.x - 3.5.x, 4.0.x | 0.2.10             |
-| **0.1.x**    | Compatible with Spring Boot 2.0.x - 2.7.x        | 0.1.10             |
+| **0.2.x**    | Compatible with Spring Boot 3.0.x - 3.5.x, 4.0.x | 0.2.11             |
+| **0.1.x**    | Compatible with Spring Boot 2.0.x - 2.7.x        | 0.1.11             |
 
 Then add the specific modules you need:
 
 ```xml
+
 <dependencies>
     <!-- Microsphere Spring Boot Core -->
     <dependency>
@@ -131,7 +132,8 @@ We welcome your contributions! Please read [Code of Conduct](./CODE_OF_CONDUCT.m
 
 ## Reporting Issues
 
-* Before you log a bug, please search the [issues](https://github.com/microsphere-projects/microsphere-spring-boot/issues)
+* Before you log a bug, please search
+  the [issues](https://github.com/microsphere-projects/microsphere-spring-boot/issues)
   to see if someone has already reported the problem.
 * If the issue doesn't already
   exist, [create a new issue](https://github.com/microsphere-projects/microsphere-spring-boot/issues/new).

--- a/microsphere-spring-boot-actuator/src/main/java/io/microsphere/spring/boot/actuate/autoconfigure/ActuatorAutoConfiguration.java
+++ b/microsphere-spring-boot-actuator/src/main/java/io/microsphere/spring/boot/actuate/autoconfigure/ActuatorAutoConfiguration.java
@@ -16,7 +16,6 @@
  */
 package io.microsphere.spring.boot.actuate.autoconfigure;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import io.microsphere.annotation.ConfigurationProperty;
 import io.microsphere.spring.boot.actuate.MonitoredThreadPoolTaskScheduler;
 import org.springframework.beans.factory.annotation.Value;
@@ -88,6 +87,12 @@ public class ActuatorAutoConfiguration {
     public static final String ACTUATOR_TASK_SCHEDULER_SERVICE_BEAN_NAME = "actuatorTaskScheduler";
 
     /**
+     * The class name of {@link io.micrometer.core.instrument.MeterRegistry}
+     * @see io.micrometer.core.instrument.MeterRegistry
+     */
+    static final String METER_REGISTRY_CLASS_NAME = "io.micrometer.core.instrument.MeterRegistry";
+
+    /**
      * Creates a {@link MonitoredThreadPoolTaskScheduler} bean for actuator tasks, configured
      * with the given pool size and thread name prefix.
      *
@@ -103,7 +108,7 @@ public class ActuatorAutoConfiguration {
      * @param threadNamePrefix the prefix for thread names created by the scheduler
      * @return a configured {@link ThreadPoolTaskScheduler} instance
      */
-    @ConditionalOnBean(MeterRegistry.class)
+    @ConditionalOnBean(type = METER_REGISTRY_CLASS_NAME)
     @Bean(name = ACTUATOR_TASK_SCHEDULER_SERVICE_BEAN_NAME, destroyMethod = "shutdown")
     public ThreadPoolTaskScheduler actuatorTaskScheduler(
             @Value(TASK_SCHEDULER_POOL_SIZE_VALUE_EXPRESSION) int poolSize,

--- a/microsphere-spring-boot-actuator/src/test/java/io/microsphere/spring/boot/actuate/autoconfigure/ActuatorAutoConfigurationTest.java
+++ b/microsphere-spring-boot-actuator/src/test/java/io/microsphere/spring/boot/actuate/autoconfigure/ActuatorAutoConfigurationTest.java
@@ -66,7 +66,8 @@ class ActuatorAutoConfigurationTest {
     @SpringBootTest(
             webEnvironment = NONE,
             classes = {
-                    MeterRegistryPresent.class
+                    MeterRegistryPresent.class,
+                    ActuatorAutoConfigurationTest.class
             }, properties = {
             "microsphere.spring.boot.actuator.task-scheduler.pool-size=2",
             "microsphere.spring.boot.actuator.task-scheduler.thread-name-prefix=my-prefix",
@@ -109,7 +110,8 @@ class ActuatorAutoConfigurationTest {
     @SpringBootTest(
             webEnvironment = NONE,
             classes = {
-                    MeterRegistryAbsent.class
+                    MeterRegistryAbsent.class,
+                    ActuatorAutoConfigurationTest.class
             }, properties = {
             // Spring Boot [2.x,3.x]
             "microsphere.autoconfigure.exclude[0]=org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration",

--- a/microsphere-spring-boot-actuator/src/test/java/io/microsphere/spring/boot/actuate/autoconfigure/ActuatorAutoConfigurationTest.java
+++ b/microsphere-spring-boot-actuator/src/test/java/io/microsphere/spring/boot/actuate/autoconfigure/ActuatorAutoConfigurationTest.java
@@ -16,6 +16,7 @@
  */
 package io.microsphere.spring.boot.actuate.autoconfigure;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.ClassOrderer.OrderAnnotation;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -31,6 +32,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import static io.microsphere.spring.boot.actuate.autoconfigure.ActuatorAutoConfiguration.ACTUATOR_TASK_SCHEDULER_SERVICE_BEAN_NAME;
 import static io.microsphere.spring.boot.actuate.autoconfigure.ActuatorAutoConfiguration.DEFAULT_TASK_SCHEDULER_POOL_SIZE;
+import static io.microsphere.spring.boot.actuate.autoconfigure.ActuatorAutoConfiguration.METER_REGISTRY_CLASS_NAME;
 import static io.microsphere.spring.boot.actuate.autoconfigure.ActuatorAutoConfiguration.TASK_SCHEDULER_POOL_SIZE_PROPERTY_NAME;
 import static io.microsphere.spring.boot.actuate.autoconfigure.ActuatorAutoConfiguration.TASK_SCHEDULER_THREAD_NAME_PREFIX_PROPERTY_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,6 +55,9 @@ class ActuatorAutoConfigurationTest {
         assertEquals("1", DEFAULT_TASK_SCHEDULER_POOL_SIZE);
         assertEquals("microsphere.spring.boot.actuator.task-scheduler.pool-size", TASK_SCHEDULER_POOL_SIZE_PROPERTY_NAME);
         assertEquals("microsphere.spring.boot.actuator.task-scheduler.thread-name-prefix", TASK_SCHEDULER_THREAD_NAME_PREFIX_PROPERTY_NAME);
+        assertEquals("io.micrometer.core.instrument.MeterRegistry", METER_REGISTRY_CLASS_NAME);
+        // test for strong type check
+        assertEquals(MeterRegistry.class.getName(), METER_REGISTRY_CLASS_NAME);
     }
 
     @Order(1)

--- a/microsphere-spring-boot-core/pom.xml
+++ b/microsphere-spring-boot-core/pom.xml
@@ -65,20 +65,6 @@
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-spring-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.zookeeper</groupId>
-                    <artifactId>zookeeper</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.curator</groupId>
-                    <artifactId>curator-recipes</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.curator</groupId>
-                    <artifactId>curator-test</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/SpringBootVersion.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/SpringBootVersion.java
@@ -25,6 +25,7 @@ import io.microsphere.util.Version;
 import static io.microsphere.constants.SymbolConstants.DOT_CHAR;
 import static io.microsphere.constants.SymbolConstants.UNDER_SCORE_CHAR;
 import static io.microsphere.util.Version.of;
+import static io.microsphere.util.Version.ofVersion;
 
 /**
  * The enumeration for the released Spring Boot versions since 2.0
@@ -292,7 +293,7 @@ public enum SpringBootVersion {
 
     SPRING_BOOT_2_7_18,
 
-    CURRENT(of(org.springframework.boot.SpringBootVersion.getVersion()));
+    CURRENT(ofVersion(org.springframework.boot.SpringBootVersion.class));
 
     private final Version version;
 

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/util/SpringApplicationUtilsTest.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/util/SpringApplicationUtilsTest.java
@@ -112,7 +112,7 @@ class SpringApplicationUtilsTest {
 
     void testGetLoggingLevel(String level) {
         MockEnvironment environment = new MockEnvironment();
-        environment.setProperty(MICROSPHERE_SPRING_BOOT_LOGGING_LEVEL_PROPERTY_NAME, level);
+        environment.withProperty(MICROSPHERE_SPRING_BOOT_LOGGING_LEVEL_PROPERTY_NAME, level);
         assertEquals(level, getLoggingLevel(environment));
     }
 

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.9</microsphere-spring.version>
+        <microsphere-spring.version>0.1.11</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.3</junit-jupiter.version>

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.11</microsphere-spring.version>
+        <microsphere-spring.version>0.1.13</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.3</junit-jupiter.version>

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -53,17 +53,8 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
-
-    <repositories>
-        <repository>
-            <id>spring-milestone</id>
-            <name>Spring Portfolio Milestone Repository</name>
-            <url>https://repo.spring.io/milestone</url>
-        </repository>
-    </repositories>
 
     <profiles>
         <profile>

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -27,6 +27,14 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- JUnit BOM -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
 
             <!-- Spring Boot Dependencies -->
             <dependency>
@@ -45,7 +53,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
 

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.13</microsphere-spring.version>
+        <microsphere-spring.version>0.1.14</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.3</junit-jupiter.version>
@@ -27,14 +27,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- JUnit BOM -->
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit-jupiter.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
 
             <!-- Spring Boot Dependencies -->
             <dependency>
@@ -53,6 +45,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -53,11 +53,19 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
         </dependencies>
     </dependencyManagement>
 
-    <profiles>
+    <repositories>
+        <repository>
+            <id>spring-milestone</id>
+            <name>Spring Portfolio Milestone Repository</name>
+            <url>https://repo.spring.io/milestone</url>
+        </repository>
+    </repositories>
 
+    <profiles>
         <profile>
             <id>spring-boot-2.1</id>
             <properties>
@@ -109,6 +117,5 @@
                 <spring-boot.version>2.7.18</spring-boot.version>
             </properties>
         </profile>
-
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.2.6</version>
+        <version>0.2.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request introduces several improvements to the Maven publishing workflow and refines the actuator auto-configuration logic. The most significant changes are the automation of release notes generation using GitHub Copilot, improvements to conditional bean creation for better compatibility, and enhancements to the test suite for stronger type checks. Additionally, a new repository is added to the Maven parent POM to support milestone dependencies.

**Workflow and Release Automation**

* The Maven publishing workflow (`.github/workflows/maven-publish.yml`) now automatically generates release notes using GitHub Copilot by summarizing commits between tags and formatting them into markdown sections. The generated notes are appended to `release-notes.md` and used in the GitHub release step.
* Workflow permissions are updated: the `build` job now explicitly requests `contents: read`, and the `publish` job requests both `contents: write` and `models: read` for Copilot API access. [[1]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aR24-R25) [[2]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aR71)
* After publishing, both `pom.xml` and `release-notes.md` are staged and committed for version bumping.

**Spring Boot Actuator Auto-Configuration**

* The actuator auto-configuration now uses a string-based type for the `@ConditionalOnBean` check (`METER_REGISTRY_CLASS_NAME`) instead of a direct class reference, improving compatibility with optional dependencies. [[1]](diffhunk://#diff-5d37008f1e056732fcff01569ff888d56d544a00829b014d79823d3c99596f39R89-R94) [[2]](diffhunk://#diff-5d37008f1e056732fcff01569ff888d56d544a00829b014d79823d3c99596f39L106-R111)
* The `METER_REGISTRY_CLASS_NAME` constant is introduced for this purpose, and relevant imports are adjusted. [[1]](diffhunk://#diff-5d37008f1e056732fcff01569ff888d56d544a00829b014d79823d3c99596f39R89-R94) [[2]](diffhunk://#diff-5d37008f1e056732fcff01569ff888d56d544a00829b014d79823d3c99596f39L19)

**Testing Improvements**

* The test suite for actuator auto-configuration is updated to verify the new `METER_REGISTRY_CLASS_NAME` constant, including a strong type check against `MeterRegistry.class.getName()`. [[1]](diffhunk://#diff-998e471e084fb0e3d1f04c1471e16d5e16a7b60b32507c346294d1e3d419547aR19) [[2]](diffhunk://#diff-998e471e084fb0e3d1f04c1471e16d5e16a7b60b32507c346294d1e3d419547aR35) [[3]](diffhunk://#diff-998e471e084fb0e3d1f04c1471e16d5e16a7b60b32507c346294d1e3d419547aR58-R60)

**Maven Parent POM Updates**

* The Spring Portfolio Milestone Repository is added to the `repositories` section in `microsphere-spring-boot-parent/pom.xml` to enable resolving milestone dependencies. [[1]](diffhunk://#diff-48d0b6c0dbb16ef27680cdee6f02093d1fb49923bc7627e84f042894d7817536R56-R68) [[2]](diffhunk://#diff-48d0b6c0dbb16ef27680cdee6f02093d1fb49923bc7627e84f042894d7817536L112)