### PR TITLE
Bump microsphere-spring to 0.1.15 and add AutoRegistrationBean support

### DIFF
--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/config/AutoRegistrationBeanInitializer.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/config/AutoRegistrationBeanInitializer.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.boot.context.config;
+
+import io.microsphere.spring.context.annotation.EnableAutoRegistrationBean;
+import io.microsphere.spring.context.config.AutoRegistrationBean;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asBeanDefinitionRegistry;
+import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
+
+/**
+ * {@link ApplicationContextInitializer} class for {@link AutoRegistrationBean}
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see EnableAutoRegistrationBean
+ * @see AutoRegistrationBean
+ * @since 1.0.0
+ */
+public class AutoRegistrationBeanInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    @Override
+    public void initialize(ConfigurableApplicationContext context) {
+        ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+        BeanDefinitionRegistry registry = asBeanDefinitionRegistry(beanFactory);
+        registerBeanDefinition(registry, Config.class);
+    }
+
+    @EnableAutoRegistrationBean
+    static class Config {
+    }
+}

--- a/microsphere-spring-boot-core/src/main/resources/META-INF/spring.factories
+++ b/microsphere-spring-boot-core/src/main/resources/META-INF/spring.factories
@@ -4,7 +4,8 @@ io.microsphere.spring.context.event.EventPublishingBeanInitializer,\
 io.microsphere.spring.boot.report.ConditionEvaluationReportInitializer,\
 io.microsphere.spring.beans.factory.support.ListenableAutowireCandidateResolverInitializer,\
 io.microsphere.spring.core.env.ListenableConfigurableEnvironmentInitializer,\
-io.microsphere.spring.boot.env.config.OriginTrackedConfigurationPropertyInitializer
+io.microsphere.spring.boot.env.config.OriginTrackedConfigurationPropertyInitializer,\
+io.microsphere.spring.boot.context.config.AutoRegistrationBeanInitializer
 
 # SpringApplicationRunListener
 org.springframework.boot.SpringApplicationRunListener=\

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/config/AutoRegistrationBeanInitializerTest.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/config/AutoRegistrationBeanInitializerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.boot.context.config;
+
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link AutoRegistrationBeanInitializer} Test
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see AutoRegistrationBeanInitializer
+ * @since 1.0.0
+ */
+@SpringJUnitConfig(
+        initializers = AutoRegistrationBeanInitializer.class
+)
+class AutoRegistrationBeanInitializerTest {
+
+    @Nested
+    @DisplayName("Enable AutoRegistrationBeanInitializer Test")
+    class EnableTest {
+
+        @Autowired
+        private ConfigurableApplicationContext context;
+
+        @Test
+        void test() {
+            assertTrue(context.containsBean("testAutoRegistrationBean"));
+        }
+    }
+
+    @Nested
+    @TestPropertySource(
+            properties = "microsphere.spring.beans.auto-registered=false"
+    )
+    @DisplayName("Disalbed AutoRegistrationBeanInitializer Test")
+    class DisabledTest {
+
+        @Autowired
+        private ConfigurableApplicationContext context;
+
+        @Test
+        void test() {
+            assertFalse(context.containsBean("testAutoRegistrationBean"));
+        }
+    }
+
+}

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/config/TestAutoRegistrationBean.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/config/TestAutoRegistrationBean.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.boot.context.config;
+
+import io.microsphere.spring.context.config.AutoRegistrationBean;
+
+/**
+ * {@link AutoRegistrationBean} class for testing.
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see AutoRegistrationBean
+ * @since 1.0.0
+ */
+public class TestAutoRegistrationBean implements AutoRegistrationBean {
+}

--- a/microsphere-spring-boot-core/src/test/resources/META-INF/spring.factories
+++ b/microsphere-spring-boot-core/src/test/resources/META-INF/spring.factories
@@ -19,3 +19,7 @@ io.microsphere.spring.context.event.LoggingBeanFactoryListener
 org.springframework.context.ApplicationListener=\
 io.microsphere.spring.boot.context.LoggingOnceApplicationPreparedEventListener,\
 io.microsphere.spring.boot.context.LoggingOnceMainApplicationPreparedEventListener
+
+# AutoRegistrationBean
+io.microsphere.spring.context.config.AutoRegistrationBean=\
+io.microsphere.spring.boot.context.config.TestAutoRegistrationBean

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -27,13 +27,21 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- JUnit BOM -->
+
+            <!-- JUnit Jupiter -->
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>${junit-jupiter.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- Jolokia -->
+            <dependency>
+                <groupId>org.jolokia</groupId>
+                <artifactId>jolokia-core</artifactId>
+                <version>${jolokia.version}</version>
             </dependency>
 
             <!-- Spring Boot Dependencies -->
@@ -53,6 +61,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.14</microsphere-spring.version>
+        <microsphere-spring.version>0.1.15</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.3</junit-jupiter.version>


### PR DESCRIPTION
This pull request introduces a new auto-registration mechanism for beans in Spring Boot applications, along with its integration and testing. The main focus is on automatically registering beans that implement the `AutoRegistrationBean` interface, making configuration more streamlined and easier to manage. Additionally, the parent POM is updated to include new dependency versions and Jolokia support.

**Auto-registration feature and integration:**

* Added `AutoRegistrationBeanInitializer`, an `ApplicationContextInitializer` that automatically registers beans annotated with `@EnableAutoRegistrationBean` into the Spring context (`AutoRegistrationBeanInitializer.java`).
* Registered `AutoRegistrationBeanInitializer` in `META-INF/spring.factories` to ensure it is picked up by Spring Boot during application startup.

**Testing and configuration:**

* Introduced `AutoRegistrationBeanInitializerTest` to verify that beans are correctly auto-registered or excluded based on configuration properties (`AutoRegistrationBeanInitializerTest.java`).
* Added a test implementation `TestAutoRegistrationBean` for use in the auto-registration tests (`TestAutoRegistrationBean.java`).
* Registered `TestAutoRegistrationBean` for the `AutoRegistrationBean` interface in the test `spring.factories` file.

**Build and dependency updates:**

* Upgraded `microsphere-spring.version` to `0.1.15` and added `jolokia-core` as a managed dependency in the parent POM (`pom.xml`). [[1]](diffhunk://#diff-48d0b6c0dbb16ef27680cdee6f02093d1fb49923bc7627e84f042894d7817536L22-R31) [[2]](diffhunk://#diff-48d0b6c0dbb16ef27680cdee6f02093d1fb49923bc7627e84f042894d7817536R40-R46) [[3]](diffhunk://#diff-48d0b6c0dbb16ef27680cdee6f02093d1fb49923bc7627e84f042894d7817536R64)