### PR TITLE
Split AutoRegistration tests into separate classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **0.2.x**    | Compatible with Spring Boot 3.0.x - 3.5.x, 4.0.x | 0.2.11             |
-| **0.1.x**    | Compatible with Spring Boot 2.0.x - 2.7.x        | 0.1.11             |
+| **0.2.x**    | Compatible with Spring Boot 3.0.x - 3.5.x, 4.0.x | 0.2.12             |
+| **0.1.x**    | Compatible with Spring Boot 2.0.x - 2.7.x        | 0.1.12             |
 
 Then add the specific modules you need:
 

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/config/DisabledAutoRegistrationBeanInitializerTest.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/config/DisabledAutoRegistrationBeanInitializerTest.java
@@ -22,12 +22,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
- * {@link AutoRegistrationBeanInitializer} Test
+ * {@link AutoRegistrationBeanInitializer} Test for disabled
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see AutoRegistrationBeanInitializer
@@ -36,14 +37,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SpringJUnitConfig(
         initializers = AutoRegistrationBeanInitializer.class
 )
-class AutoRegistrationBeanInitializerTest {
+@TestPropertySource(
+        properties = "microsphere.spring.beans.auto-registered=false"
+)
+class DisabledAutoRegistrationBeanInitializerTest {
 
     @Autowired
     private ConfigurableApplicationContext context;
 
     @Test
-    @DisplayName("Enable AutoRegistrationBeanInitializer Test")
+    @DisplayName("Disalbed AutoRegistrationBeanInitializer Test")
     void test() {
-        assertTrue(context.containsBean("testAutoRegistrationBean"));
+        assertFalse(context.containsBean("testAutoRegistrationBean"));
     }
 }


### PR DESCRIPTION
Extract the disabled nested test into a new DisabledAutoRegistrationBeanInitializerTest class (with @TestPropertySource(properties = "microsphere.spring.beans.auto-registered=false")). Simplify AutoRegistrationBeanInitializerTest by removing @Nested classes and making the enabled test a top-level @Test that asserts the presence of the testAutoRegistrationBean. Adjusted imports accordingly to reflect the rearranged tests.