### PR TITLE
Update Maven workflows, credentials, and dependency versions

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -36,9 +36,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          cache: maven
 
       - name: Build with Maven
-        run: ./mvnw
+        run: mvn
           --batch-mode
           --update-snapshots
           --file pom.xml

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -21,7 +21,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 7
       matrix:
         java: [ '8', '11' , '17' , '21' , '25' ]
         maven-profile-spring-boot: [ 'spring-boot-2.1' , 'spring-boot-2.2' , 'spring-boot-2.3',

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v5
 
-      - name: Setup JDK ${{ matrix.Java }}
+      - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -40,13 +40,9 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          cache: maven
 
       - name: Publish package
-        run: mvn
+        run: ./mvnw
           --batch-mode
           --update-snapshots
           --file pom.xml

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
 
       - name: Publish package
         run: ./mvnw

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **0.2.x**    | Compatible with Spring Boot 3.0.x - 3.5.x, 4.0.x | 0.2.12             |
-| **0.1.x**    | Compatible with Spring Boot 2.0.x - 2.7.x        | 0.1.12             |
+| **0.2.x**    | Compatible with Spring Boot 3.0.x - 3.5.x, 4.0.x | 0.2.13             |
+| **0.1.x**    | Compatible with Spring Boot 2.0.x - 2.7.x        | 0.1.13             |
 
 Then add the specific modules you need:
 

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -22,7 +22,7 @@
         <microsphere-spring.version>0.1.15</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
-        <junit-jupiter.version>5.14.3</junit-jupiter.version>
+        <junit-jupiter.version>5.14.4</junit-jupiter.version>
     </properties>
 
     <dependencyManagement>

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.15</microsphere-spring.version>
+        <microsphere-spring.version>0.1.16</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.2.7</version>
+        <version>0.2.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request includes updates to the build configuration and dependency versions, as well as minor documentation updates. The main changes are improvements to the Maven build and publish workflows, and version bumps for several dependencies.

**Build workflow updates:**

* Updated `.github/workflows/maven-build.yml` to use the official `mvn` command instead of the wrapper, set up Java with caching for Maven dependencies, and fixed a casing issue in the matrix variable.
* Updated `.github/workflows/maven-publish.yml` to use the Maven wrapper (`./mvnw`) instead of the system Maven, and removed the redundant Maven cache configuration.

**Dependency and version updates:**

* Bumped the parent project version in `pom.xml` from `0.2.7` to `0.2.9`.
* Updated `microsphere-spring.version` from `0.1.15` to `0.1.16` and `junit-jupiter.version` from `5.14.3` to `5.14.4` in `microsphere-spring-boot-parent/pom.xml`.

**Documentation:**

* Updated the `README.md` to reflect the latest released versions: `0.2.13` and `0.1.13`.