### PR TITLE
Revamp README and add new agent prompt templates

### DIFF
--- a/.github/prompts/create-readme.prompt.md
+++ b/.github/prompts/create-readme.prompt.md
@@ -1,0 +1,45 @@
+---
+agent: 'agent'
+description: 'Create a comprehensive README.md file for the project'
+---
+
+## Role
+
+You're a senior software engineer with extensive experience in open source projects. You create appealing, informative, and easy-to-read README files.
+
+## Task
+
+1. Review the entire project workspace and codebase
+2. Create a comprehensive README.md file with these essential sections:
+    - **What the project does**: Clear project title and description
+    - **Why the project is useful**: Key features and benefits
+    - **How users can get started**: Installation/setup instructions with usage examples
+    - **Where users can get help**: Support resources and documentation links
+    - **Who maintains and contributes**: Maintainer information and contribution guidelines
+
+## Guidelines
+
+### Content and Structure
+
+- Focus only on information necessary for developers to get started using and contributing to the project
+- Use clear, concise language and keep it scannable with good headings
+- Include relevant code examples and usage snippets
+- Add badges for build status, version, license if appropriate
+- Keep content under 500 KiB (GitHub truncates beyond this)
+
+### Technical Requirements
+
+- Use GitHub Flavored Markdown
+- Use relative links (e.g., `docs/CONTRIBUTING.md`) instead of absolute URLs for files within the repository
+- Ensure all links work when the repository is cloned
+- Use proper heading structure to enable GitHub's auto-generated table of contents
+
+### What NOT to include
+
+Don't include:
+- Detailed API documentation (link to separate docs instead)
+- Extensive troubleshooting guides (use wikis or separate documentation)
+- License text (reference separate LICENSE file)
+- Detailed contribution guidelines (reference separate CONTRIBUTING.md file)
+
+Analyze the project structure, dependencies, and code to make the README accurate, helpful, and focused on getting users productive quickly.

--- a/.github/prompts/document-api.prompt.md
+++ b/.github/prompts/document-api.prompt.md
@@ -1,0 +1,52 @@
+---
+agent: 'agent'
+description: 'Generate OpenAPI 3.0 specification for API endpoints'
+---
+
+## Task
+
+Analyze the API endpoint code and generate a valid OpenAPI 3.0 specification in YAML format.
+
+## OpenAPI Structure
+
+Generate a complete OpenAPI spec including:
+
+1. **OpenAPI Header**
+    - OpenAPI version (3.0.3)
+    - API info (title, description, version)
+    - Server configuration
+
+2. **Path Definitions**
+    - HTTP method and path
+    - Operation summary and description
+    - Tags for organization
+
+3. **Parameters Schema**
+    - Path parameters with type validation
+    - Query parameters with constraints and defaults
+    - Request body schema using proper JSON Schema
+    - Required vs optional parameters
+
+4. **Response Schemas**
+    - Success responses (200, 201, etc.) with schema definitions
+    - Error responses (400, 401, 404, 500) with error schema
+    - Content-Type specifications
+    - Realistic example values
+
+5. **Components Section**
+    - Reusable schemas for request/response models
+    - Security schemes (Bearer token, API key, etc.)
+    - Common parameter definitions
+
+## Requirements
+
+- Generate valid OpenAPI 3.0.3 YAML that passes validation
+- Use proper JSON Schema for all data models
+- Include realistic example values, not placeholders
+- Define reusable components to avoid duplication
+- Add appropriate data validation (required fields, formats, constraints)
+- Include security requirements where applicable
+
+Focus on: ${input:endpoint_focus:Which specific endpoint or endpoints should be documented?}
+
+Generate production-ready OpenAPI specification that can be used with Swagger UI, Postman, and code generators.

--- a/.github/prompts/explain-code.prompt.md
+++ b/.github/prompts/explain-code.prompt.md
@@ -1,0 +1,19 @@
+---
+agent: 'agent'
+description: 'Generate a clear code explanation with examples'
+---
+
+Explain the following code in a clear, beginner-friendly way:
+
+Code to explain: ${input:code:Paste your code here}
+Target audience: ${input:audience:Who is this explanation for? (e.g., beginners, intermediate developers, etc.)}
+
+Please provide:
+
+* A brief overview of what the code does
+* A step-by-step breakdown of the main parts
+* Explanation of any key concepts or terminology
+* A simple example showing how it works
+* Common use cases or when you might use this approach
+
+Use clear, simple language and avoid unnecessary jargon.

--- a/.github/prompts/generate-unit-tests.prompt.md
+++ b/.github/prompts/generate-unit-tests.prompt.md
@@ -1,0 +1,52 @@
+---
+agent: 'agent'
+description: 'Generate unit tests for selected functions or methods'
+---
+
+## Task
+
+Analyze the selected function/method and generate focused unit tests that thoroughly validate its behavior.
+
+## Test Generation Strategy
+
+1. **Core Functionality Tests**
+    - Test the main purpose/expected behavior
+    - Verify return values with typical inputs
+    - Test with realistic data scenarios
+
+2. **Input Validation Tests**
+    - Test with invalid input types
+    - Test with null/undefined values
+    - Test with empty strings/arrays/objects
+    - Test boundary values (min/max, zero, negative numbers)
+
+3. **Error Handling Tests**
+    - Test expected exceptions are thrown
+    - Verify error messages are meaningful
+    - Test graceful handling of edge cases
+
+4. **Side Effects Tests** (if applicable)
+    - Verify external calls are made correctly
+    - Test state changes
+    - Validate interactions with dependencies
+
+## Test Structure Requirements
+
+- Use existing project testing framework and patterns
+- Follow AAA pattern: Arrange, Act, Assert
+- Write descriptive test names that explain the scenario
+- Group related tests in describe/context blocks
+- Mock external dependencies cleanly
+
+Target function: ${input:function_name:Which function or method should be tested?}
+Testing framework: ${input:framework:Which framework? (jest/vitest/mocha/pytest/rspec/etc)}
+
+## Guidelines
+
+- Generate 5-8 focused test cases covering the most important scenarios
+- Include realistic test data, not just simple examples
+- Add comments for complex test setup or assertions
+- Ensure tests are independent and can run in any order
+- Focus on testing behavior, not implementation details
+
+Create tests that give confidence the function works correctly and help catch regressions.

--- a/.github/prompts/onboarding-plan.prompt.md
+++ b/.github/prompts/onboarding-plan.prompt.md
@@ -1,0 +1,26 @@
+---
+agent: 'agent'
+description: 'Help new team members onboard with a phased plan and suggestions for first tasks.'
+---
+
+# Create My Onboarding Plan
+
+I'm a new team member joining [Microsphere Projects](https://github.com/microsphere-projects) and I need help creating a structured onboarding plan.
+
+My background: the experienced developer new to this stack
+
+Please create a personalized phased onboarding plan that includes the following phases.
+
+## Phase 1 - Foundation
+
+Environment setup with step-by-step instructions and troubleshooting tips, plus identifying the most important documentation to read first
+
+## Phase 2 - Exploration
+
+Codebase discovery starting with README files, running existing tests/scripts to understand workflows, and finding beginner-friendly first tasks like documentation improvements. If possible, find me specific open issues or tasks that are suitable for my background.
+
+## Phase 3 - Integration
+
+Learning team processes, making first contributions, and building confidence through early wins
+
+For each phase, break down complex topics into manageable steps, recommend relevant resources, provide concrete next steps, and suggest hands-on practice over just reading theory.

--- a/.github/prompts/review-code.prompt.md
+++ b/.github/prompts/review-code.prompt.md
@@ -1,0 +1,59 @@
+---
+agent: 'agent'
+description: 'Perform a comprehensive code review'
+---
+
+## Role
+
+You're a senior software engineer conducting a thorough code review. Provide constructive, actionable feedback.
+
+## Review Areas
+
+Analyze the selected code for:
+
+1. **Security Issues**
+    - Input validation and sanitization
+    - Authentication and authorization
+    - Data exposure risks
+    - Injection vulnerabilities
+
+2. **Performance & Efficiency**
+    - Algorithm complexity
+    - Memory usage patterns
+    - Database query optimization
+    - Unnecessary computations
+
+3. **Code Quality**
+    - Readability and maintainability
+    - Proper naming conventions
+    - Function/class size and responsibility
+    - Code duplication
+
+4. **Architecture & Design**
+    - Design pattern usage
+    - Separation of concerns
+    - Dependency management
+    - Error handling strategy
+
+5. **Testing & Documentation**
+    - Test coverage and quality
+    - Documentation completeness
+    - Comment clarity and necessity
+
+## Output Format
+
+Provide feedback as:
+
+**🔴 Critical Issues** - Must fix before merge
+**🟡 Suggestions** - Improvements to consider
+**✅ Good Practices** - What's done well
+
+For each issue:
+- Specific line references
+- Clear explanation of the problem
+- Suggested solution with code example
+- Rationale for the change
+
+Focus on: ${input:focus:Any specific areas to emphasize in the review?}
+
+Be constructive and educational in your feedback.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/microsphere-projects/microsphere-spring-boot)
 [![zread](https://img.shields.io/badge/Ask_Zread-_.svg?style=flat&color=00b0aa&labelColor=000000&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTQuOTYxNTYgMS42MDAxSDIuMjQxNTZDMS44ODgxIDEuNjAwMSAxLjYwMTU2IDEuODg2NjQgMS42MDE1NiAyLjI0MDFWNC45NjAxQzEuNjAxNTYgNS4zMTM1NiAxLjg4ODEgNS42MDAxIDIuMjQxNTYgNS42MDAxSDQuOTYxNTZDNS4zMTUwMiA1LjYwMDEgNS42MDE1NiA1LjMxMzU2IDUuNjAxNTYgNC45NjAxVjIuMjQwMUM1LjYwMTU2IDEuODg2NjQgNS4zMTUwMiAxLjYwMDEgNC45NjE1NiAxLjYwMDFaIiBmaWxsPSIjZmZmIi8%2BCjxwYXRoIGQ9Ik00Ljk2MTU2IDEwLjM5OTlIMi4yNDE1NkMxLjg4ODEgMTAuMzk5OSAxLjYwMTU2IDEwLjY4NjQgMS42MDE1NiAxMS4wMzk5VjEzLjc1OTlDMS42MDE1NiAxNC4xMTM0IDEuODg4MSAxNC4zOTk5IDIuMjQxNTYgMTQuMzk5OUg0Ljk2MTU2QzUuMzE1MDIgMTQuMzk5OSA1LjYwMTU2IDE0LjExMzQgNS42MDE1NiAxMy43NTk5VjExLjAzOTlDNS42MDE1NiAxMC42ODY0IDUuMzE1MDIgMTAuMzk5OSA0Ljk2MTU2IDEwLjM5OTlaIiBmaWxsPSIjZmZmIi8%2BCjxwYXRoIGQ9Ik0xMy43NTg0IDEuNjAwMUgxMS4wMzg0QzEwLjY4NSAxLjYwMDEgMTAuMzk4NCAxLjg4NjY0IDEwLjM5ODQgMi4yNDAxVjQuOTYwMUMxMC4zOTg0IDUuMzEzNTYgMTAuNjg1IDUuNjAwMSAxMS4wMzg0IDUuNjAwMUgxMy43NTg0QzE0LjExMTkgNS42MDAxIDE0LjM5ODQgNS4zMTM1NiAxNC4zOTg0IDQuOTYwMVYyLjI0MDFDMTQuMzk4NCAxLjg4NjY0IDE0LjExMTkgMS42MDAxIDEzLjc1ODQgMS42MDAxWiIgZmlsbD0iI2ZmZiIvPgo8cGF0aCBkPSJNNCAxMkwxMiA0TDQgMTJaIiBmaWxsPSIjZmZmIi8%2BCjxwYXRoIGQ9Ik00IDEyTDEyIDQiIHN0cm9rZT0iI2ZmZiIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgo8L3N2Zz4K&logoColor=ffffff)](https://zread.ai/microsphere-projects/microsphere-spring-boot)
 [![Maven Build](https://github.com/microsphere-projects/microsphere-spring-boot/actions/workflows/maven-build.yml/badge.svg)](https://github.com/microsphere-projects/microsphere-spring-boot/actions/workflows/maven-build.yml)
-[![Codecov](https://codecov.io/gh/microsphere-projects/microsphere-spring-boot/branch/dev-1.x/graph/badge.svg)](https://app.codecov.io/gh/microsphere-projects/microsphere-spring-boot)
+[![Codecov](https://codecov.io/gh/microsphere-projects/microsphere-spring-boot/branch/main/graph/badge.svg)](https://app.codecov.io/gh/microsphere-projects/microsphere-spring-boot)
 ![Maven](https://img.shields.io/maven-central/v/io.github.microsphere-projects/microsphere-spring-boot.svg)
 ![License](https://img.shields.io/github/license/microsphere-projects/microsphere-spring-boot.svg)
 
@@ -13,38 +13,88 @@ Microsphere Spring Boot is a collection of libraries that extends Spring Boot's 
 focused on configuration management, application diagnostics, and enhanced monitoring. The project is structured as a
 multi-module Maven project that follows Spring Boot's conventions while providing value-added functionality.
 
-## Purpose and Scope
+## Table of Contents
 
-The Microsphere Spring Boot project is a collection of Spring Boot extensions that enhance observability, configuration
-management, and operational capabilities for Spring Boot applications. It provides:
+- [What the Project Does](#what-the-project-does)
+- [Why the Project is Useful](#why-the-project-is-useful)
+- [Modules](#modules)
+- [Getting Started](#getting-started)
+    - [Prerequisites](#prerequisites)
+    - [Add the BOM](#add-the-bom)
+    - [Add Module Dependencies](#add-module-dependencies)
+- [Usage](#usage)
+    - [Default Properties](#default-properties)
+    - [Excluding Auto-Configurations](#excluding-auto-configurations)
+    - [Configuration Properties Binding Listeners](#configuration-properties-binding-listeners)
+    - [Actuator Endpoints](#actuator-endpoints)
+    - [Monitored Task Scheduler](#monitored-task-scheduler)
+    - [Classpath Artifact Detection](#classpath-artifact-detection)
+- [Building from Source](#building-from-source)
+- [Getting Help](#getting-help)
+- [Contributing](#contributing)
+- [Maintainers](#maintainers)
+- [License](#license)
 
-- Enhanced Auto-Configuration: Sophisticated auto-configuration mechanisms with filtering and property management
-- Custom Actuator Endpoints: Extended Spring Boot Actuator with additional endpoints for configuration metadata and
-  application artifacts
-- Monitoring Extensions: Enhanced task scheduling with metrics integration via Micrometer
-- Configuration Management: Advanced configuration binding and property management features
-- Multi-Version Support: Compatibility across Spring Boot versions 3.0 through 3.4
+## What the Project Does
+
+Microsphere Spring Boot provides production-ready enhancements for Spring Boot applications, covering:
+
+- **Default Properties**: Pre-configured sensible defaults (graceful shutdown, MVC filter toggling) loaded from
+  `config/default/*.properties` on the classpath, which can be overridden per-module.
+- **Advanced Auto-Configuration Management**: A configurable import filter that allows merging multiple
+  `microsphere.autoconfigure.exclude` property sources without losing earlier exclusions.
+- **Configuration Property Binding Listeners**: Event-driven hooks (`BindListener`) that notify your beans whenever a
+  `@ConfigurationProperties`-bound property value changes.
+- **Custom Actuator Endpoints**: Four additional actuator endpoints that expose classpath artifact metadata,
+  web-endpoint mappings, configuration metadata, and bound configuration properties.
+- **Monitored Task Scheduler**: A `ThreadPoolTaskScheduler` wrapper that records execution metrics via Micrometer,
+  giving you task latency and count out of the box.
+- **Artifact Collision Detection**: Startup-time detection of duplicate JAR artifacts on the classpath, surfaced as a
+  descriptive `FailureAnalyzer` message.
+- **Multi-Version Compatibility**: A dedicated compatibility shim module keeps the codebase working with Spring Boot
+  2.x through 4.x without requiring separate forks.
+
+## Why the Project is Useful
+
+| Benefit                                | Detail                                                                                                                       |
+|----------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| **Opinionated defaults**               | Sensible, overridable defaults (graceful shutdown, disabled noisy filters) reduce boilerplate in every application.          |
+| **Observable configuration**           | Know immediately when any `@ConfigurationProperties` value changes at runtime via `BindListener`.                            |
+| **Richer actuator surface**            | Four extra endpoints (`/actuator/microsphere/*`) expose the runtime state that Spring Boot's built-in endpoints don't cover. |
+| **Safe auto-configuration exclusions** | `microsphere.autoconfigure.exclude` merges all sources; the standard `spring.autoconfigure.exclude` replaces them.           |
+| **Scheduling metrics**                 | `MonitoredThreadPoolTaskScheduler` instruments every scheduled task with Micrometer counters and timers at zero config.      |
+| **Dependency health**                  | Banned-artifact and collision detection catches classpath problems at startup rather than at runtime.                        |
+| **Long Spring Boot lifecycle**         | Supports Spring Boot 2.0 – 4.x across two maintained release lines (`0.1.x` for Boot 2, `0.2.x` for Boot 3/4).               |
 
 ## Modules
 
-| **Module**                               | **Purpose**                                                                        |
-|------------------------------------------|------------------------------------------------------------------------------------|
-| **microsphere-spring-parent**            | Defines the parent POM with dependency management and Spring Boot version profiles |
-| **microsphere-spring-boot-dependencies** | Centralizes dependency management for all project modules                          |
-| **microsphere-spring-boot-core**         | Provides core functionality for enhanced Spring Boot applications                  |
-| **microsphere-spring-boot-actuator**     | Extends Spring Boot Actuator with additional endpoints and monitoring capabilities |
+| **Module**                               | **Artifact ID**                        | **Purpose**                                                                                   |
+|------------------------------------------|----------------------------------------|-----------------------------------------------------------------------------------------------|
+| **microsphere-spring-boot-parent**       | `microsphere-spring-boot-parent`       | Parent POM: build plugins, Java 17 baseline, Spring Boot version profiles                     |
+| **microsphere-spring-boot-dependencies** | `microsphere-spring-boot-dependencies` | BOM — import this to manage all module versions                                               |
+| **microsphere-spring-boot-compatible**   | `microsphere-spring-boot-compatible`   | Compatibility shims for running across Spring Boot 2.x – 4.x (not published to Maven Central) |
+| **microsphere-spring-boot-core**         | `microsphere-spring-boot-core`         | Core features: default properties, auto-configuration filter, bind listeners, diagnostics     |
+| **microsphere-spring-boot-actuator**     | `microsphere-spring-boot-actuator`     | Actuator extensions: custom endpoints, monitored scheduler, opinionated endpoint defaults     |
 
 ## Getting Started
 
-The easiest way to get started is by adding the Microsphere Spring Boot BOM (Bill of Materials) to your project's
-pom.xml:
+### Prerequisites
+
+| Requirement | Version                                                             |
+|-------------|---------------------------------------------------------------------|
+| Java        | 17+                                                                 |
+| Maven       | 3.9+ (or use the included `mvnw` wrapper)                           |
+| Spring Boot | 3.0.x – 3.5.x, 4.0.x (`main` branch) / 2.0.x – 2.7.x (`1.x` branch) |
+
+### Add the BOM
+
+Import the Microsphere Spring Boot BOM into your `pom.xml` so all module versions are managed for you:
 
 ```xml
 
 <dependencyManagement>
     <dependencies>
-        ...
-        <!-- Microsphere Spring Boot Dependencies -->
+        <!-- Microsphere Spring Boot BOM -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-spring-boot-dependencies</artifactId>
@@ -52,30 +102,31 @@ pom.xml:
             <type>pom</type>
             <scope>import</scope>
         </dependency>
-        ...
     </dependencies>
 </dependencyManagement>
 ```
 
-`${microsphere-spring-boot.version}` has two branches:
+Choose the version that matches your Spring Boot generation:
 
-| **Branches** | **Purpose**                                      | **Latest Version** |
-|--------------|--------------------------------------------------|--------------------|
-| **main**     | Compatible with Spring Boot 3.0.x - 3.5.x, 4.0.x | 0.2.13             |
-| **1.x**      | Compatible with Spring Boot 2.0.x - 2.7.x        | 0.1.13             |
+| Branch | Spring Boot Compatibility | Latest Version |
+|--------|---------------------------|----------------|
+| `main` | 3.0.x – 3.5.x, 4.0.x      | `0.2.13`       |
+| `1.x`  | 2.0.x – 2.7.x             | `0.1.13`       |
 
-Then add the specific modules you need:
+### Add Module Dependencies
+
+After importing the BOM, add only the modules you need — no version required:
 
 ```xml
 
 <dependencies>
-    <!-- Microsphere Spring Boot Core -->
+    <!-- Core features: default properties, auto-config filter, bind listeners, diagnostics -->
     <dependency>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-boot-core</artifactId>
     </dependency>
 
-    <!-- Microsphere Spring Boot Actuator -->
+    <!-- Actuator extensions: custom endpoints, monitored scheduler -->
     <dependency>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-boot-actuator</artifactId>
@@ -83,79 +134,187 @@ Then add the specific modules you need:
 </dependencies>
 ```
 
-### Example : Using the default properties to disable the Auto-Configuration of Spring Boot
+## Usage
 
-The module `microsphere-spring-boot-core` offers the default properties, which can be used to disable the
-auto-configuration:
+### Default Properties
 
-1. To add the default properties resource(located classpath `config/default/test.properties`):
+`microsphere-spring-boot-core` automatically loads property files from `config/default/*.properties` on the classpath.
+The built-in `core.properties` enables graceful shutdown and disables several noisy Spring MVC filters out of the box:
 
 ```properties
-### Exclude Spring Boot Built-in Auto-Configuration Class
-microsphere.autoconfigure.exclude=\
-org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
+# Graceful shutdown (built into core.properties)
+server.shutdown=graceful
+spring.lifecycle.timeout-per-shutdown-phase=60s
+# Disabled by default
+spring.mvc.hiddenmethod.filter.enabled=false
+spring.mvc.formcontent.filter.enabled=false
 ```
 
-> Alternatively, you can also use the `@EnableAutoConfiguration` annotation with `exclude` attribute or the Spring
-> property `spring.autoconfigure.exclude` to exclude the auto-configuration, however, these two approaches can't merge
-> the previous properties.
+To add your own module-level defaults, place a file at `config/default/<your-module>.properties` on the classpath.
+These files are merged together, so none of the values from other modules are lost.
+
+### Excluding Auto-Configurations
+
+`microsphere.autoconfigure.exclude` works like Spring Boot's standard `spring.autoconfigure.exclude` but **merges**
+values from all property sources instead of replacing them. Add it to any default-properties file or to
+`application.properties`:
+
+```properties
+# config/default/my-module.properties
+microsphere.autoconfigure.exclude=\
+  org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration,\
+  org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration
+```
+
+> **Tip:** Use `microsphere.autoconfigure.exclude` when multiple teams need to exclude different auto-configurations
+> independently. Use the standard `spring.autoconfigure.exclude` when you want a single, authoritative exclusion list.
+
+### Configuration Properties Binding Listeners
+
+Register a `BindListener` bean to be notified whenever a `@ConfigurationProperties`-bound property changes:
+
+```java
+import io.microsphere.spring.boot.context.properties.bind.BindListener;
+import org.springframework.boot.context.properties.bind.BindContext;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MyBindListener implements BindListener {
+
+    @Override
+    public void onStart(ConfigurationPropertyName name, Bindable<?> target, BindContext context) {
+        // called before binding
+    }
+
+    @Override
+    public void onSuccess(ConfigurationPropertyName name, Bindable<?> target,
+                          BindContext context, Object result) {
+        System.out.println("Bound " + name + " = " + result);
+    }
+}
+```
+
+A `ConfigurationPropertiesBeanPropertyChangedEvent` is also published to the Spring `ApplicationContext` whenever a
+`@ConfigurationProperties` bean property value changes, so you can use `@EventListener` as an alternative.
+
+### Actuator Endpoints
+
+`microsphere-spring-boot-actuator` registers four additional actuator endpoints (all enabled by default):
+
+| Endpoint           | Default Path                              | Description                                                                       |
+|--------------------|-------------------------------------------|-----------------------------------------------------------------------------------|
+| `artifacts`        | `/actuator/microsphere/artifacts`         | Lists all JAR artifacts detected on the classpath                                 |
+| `webEndpoints`     | `/actuator/microsphere/web/endpoints`     | Lists all registered Spring MVC / WebFlux actuator endpoint mappings              |
+| `configMetadata`   | `/actuator/microsphere/config/metadata`   | Exposes Spring Boot configuration metadata (`spring-configuration-metadata.json`) |
+| `configProperties` | `/actuator/microsphere/config/properties` | Exposes all currently bound `@ConfigurationProperties` values                     |
+
+The module also ships with an opinionated `endpoints.properties` default that enables only the most-used standard
+endpoints (`health`, `info`, `env`, `loggers`, `metrics`, `mappings`, `prometheus`, `jolokia`) and configures
+appropriate TTL-based caching for every endpoint.
+
+### Monitored Task Scheduler
+
+Replace `ThreadPoolTaskScheduler` with `MonitoredThreadPoolTaskScheduler` to get automatic Micrometer metrics
+(task count, execution time) for every scheduled task:
+
+```java
+import io.micrometer.core.instrument.MeterRegistry;
+import io.microsphere.spring.boot.actuate.MonitoredThreadPoolTaskScheduler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SchedulerConfig {
+
+    @Bean
+    public MonitoredThreadPoolTaskScheduler taskScheduler(MeterRegistry meterRegistry) {
+        MonitoredThreadPoolTaskScheduler scheduler = new MonitoredThreadPoolTaskScheduler(meterRegistry);
+        scheduler.setPoolSize(4);
+        return scheduler;
+    }
+}
+```
+
+### Classpath Artifact Detection
+
+`BannedArtifactClassLoadingListener` checks for explicitly banned JARs at startup. If a banned artifact is detected,
+the application fails fast with a human-readable `FailureAnalyzer` message that identifies the offending dependency.
+
+The collision detector (`ArtifactsCollisionDiagnosisListener`) also checks for duplicate versions of the same artifact
+and raises `ArtifactsCollisionException` with full classpath details so you can fix the conflict before the application
+reaches production.
 
 ## Building from Source
 
 You don't need to build from source unless you want to try out the latest code or contribute to the project.
 
-To build the project, follow these steps:
-
 1. Clone the repository:
 
 ```bash
 git clone https://github.com/microsphere-projects/microsphere-spring-boot.git
+cd microsphere-spring-boot
 ```
 
-2. Build the source:
+2. Build and run tests:
 
-- Linux/MacOS:
+   **Linux / macOS**
 
-```bash
-./mvnw package
-```
+   ```bash
+   ./mvnw verify
+   ```
 
-- Windows:
+   **Windows**
 
-```powershell
-mvnw.cmd package
-```
+   ```powershell
+   mvnw.cmd verify
+   ```
+
+3. Install to your local Maven repository (skipping tests for speed):
+
+   ```bash
+   ./mvnw install -DskipTests
+   ```
+
+> **Java version:** The build requires Java 17 or later.
+
+## Getting Help
+
+| Resource                  | Link                                                                                   |
+|---------------------------|----------------------------------------------------------------------------------------|
+| **User Guide (DeepWiki)** | https://deepwiki.com/microsphere-projects/microsphere-spring-boot                      |
+| **User Guide (ZRead)**    | https://zread.ai/microsphere-projects/microsphere-spring-boot                          |
+| **GitHub Wiki**           | https://github.com/microsphere-projects/microsphere-spring-boot/wiki                   |
+| **JavaDoc — core**        | https://javadoc.io/doc/io.github.microsphere-projects/microsphere-spring-boot-core     |
+| **JavaDoc — actuator**    | https://javadoc.io/doc/io.github.microsphere-projects/microsphere-spring-boot-actuator |
+| **Issue Tracker**         | https://github.com/microsphere-projects/microsphere-spring-boot/issues                 |
+
+**Reporting a bug:**
+
+1. Search [existing issues](https://github.com/microsphere-projects/microsphere-spring-boot/issues) first.
+2. If the issue does not
+   exist, [open a new issue](https://github.com/microsphere-projects/microsphere-spring-boot/issues/new).
+3. Include the Spring Boot version, Microsphere Spring Boot version, a minimal reproducer, and any relevant logs.
 
 ## Contributing
 
-We welcome your contributions! Please read [Code of Conduct](./CODE_OF_CONDUCT.md) before submitting a pull request.
+Contributions of all kinds are welcome — bug fixes, documentation improvements, and new features.
 
-## Reporting Issues
+1. Fork the repository and create a feature branch.
+2. Make your changes and add or update tests as appropriate.
+3. Run `./mvnw verify` to ensure all tests pass before submitting.
+4. Open a pull request against the `main` branch (or `1.x` for Spring Boot 2.x fixes).
+5. Please read [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) before participating in the community.
 
-* Before you log a bug, please search
-  the [issues](https://github.com/microsphere-projects/microsphere-spring-boot/issues)
-  to see if someone has already reported the problem.
-* If the issue doesn't already
-  exist, [create a new issue](https://github.com/microsphere-projects/microsphere-spring-boot/issues/new).
-* Please provide as much information as possible with the issue report.
+## Maintainers
 
-## Documentation
+| Name     | GitHub                                       | Email                |
+|----------|----------------------------------------------|----------------------|
+| Mercy Ma | [@mercyblitz](https://github.com/mercyblitz) | mercyblitz@gmail.com |
 
-### User Guide
-
-[DeepWiki Host](https://deepwiki.com/microsphere-projects/microsphere-spring-boot)
-
-[ZRead Host](https://zread.ai/microsphere-projects/microsphere-spring-boot)
-
-### Wiki
-
-[Github Host](https://github.com/microsphere-projects/microsphere-spring-boot/wiki)
-
-### JavaDoc
-
-- [microsphere-spring-boot-core](https://javadoc.io/doc/io.github.microsphere-projects/microsphere-spring-boot-core)
-- [microsphere-spring-boot-actuator](https://javadoc.io/doc/io.github.microsphere-projects/microsphere-spring-boot-actuator)
+The project is maintained under the [Microsphere Projects](https://github.com/microsphere-projects) organisation.
 
 ## License
 
-The Microsphere Spring is released under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+Microsphere Spring Boot is released under the [Apache License 2.0](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **0.2.x**    | Compatible with Spring Boot 3.0.x - 3.5.x, 4.0.x | 0.2.13             |
-| **0.1.x**    | Compatible with Spring Boot 2.0.x - 2.7.x        | 0.1.13             |
+| **main**     | Compatible with Spring Boot 3.0.x - 3.5.x, 4.0.x | 0.2.13             |
+| **1.x**      | Compatible with Spring Boot 2.0.x - 2.7.x        | 0.1.13             |
 
 Then add the specific modules you need:
 

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.16</microsphere-spring.version>
+        <microsphere-spring.version>0.1.17</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>


### PR DESCRIPTION
This pull request adds a set of prompt templates to the `.github/prompts` directory to assist with common engineering tasks such as creating READMEs, generating OpenAPI specs, explaining code, writing unit tests, onboarding new team members, and performing code reviews. These templates are designed to standardize and streamline key workflows by providing clear instructions and requirements for each task.

**New prompt templates added:**

*README and Documentation Generation*
- Added `create-readme.prompt.md` to guide the creation of comprehensive, developer-focused README files, including required sections, formatting guidelines, and content restrictions.
- Added `document-api.prompt.md` for generating OpenAPI 3.0 specifications, with detailed requirements for structure, validation, and example data.

*Code Understanding and Testing*
- Added `explain-code.prompt.md` to produce beginner-friendly code explanations, including step-by-step breakdowns and examples.
- Added `generate-unit-tests.prompt.md` to generate thorough, framework-specific unit tests for selected functions, covering core functionality, input validation, error handling, and side effects.

*Onboarding and Code Review*
- Added `onboarding-plan.prompt.md` to provide a phased onboarding plan for new team members, with actionable steps and resource recommendations.
- Added `review-code.prompt.md` to standardize comprehensive code reviews, outlining review areas and structured feedback format.