### PR TITLE
Update POM versions and README for latest releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Choose the version that matches your Spring Boot generation:
 
 | Branch | Spring Boot Compatibility | Latest Version |
 |--------|---------------------------|----------------|
-| `main` | 3.0.x – 3.5.x, 4.0.x      | `0.2.17`       |
-| `1.x`  | 2.0.x – 2.7.x             | `0.1.17`       |
+| `main` | 3.0.x – 3.5.x, 4.0.x      | `0.2.18`       |
+| `1.x`  | 2.0.x – 2.7.x             | `0.1.18`       |
 
 ### Add Module Dependencies
 

--- a/microsphere-spring-boot-actuator/src/test/java/io/microsphere/spring/boot/actuate/autoconfigure/ActuatorEndpointsAutoConfigurationTest.java
+++ b/microsphere-spring-boot-actuator/src/test/java/io/microsphere/spring/boot/actuate/autoconfigure/ActuatorEndpointsAutoConfigurationTest.java
@@ -100,7 +100,7 @@ class ActuatorEndpointsAutoConfigurationTest {
             }
     )
     @EnableAutoConfiguration
-    class Disalbed {
+    class Disabled {
 
         @Autowired(required = false)
         private ArtifactsEndpoint artifactsEndpoint;

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.21</microsphere-spring.version>
+        <microsphere-spring.version>0.1.22</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request includes minor version updates to dependencies and documentation to ensure compatibility and reflect the latest releases.

Dependency version updates:

* Updated the parent project version in `pom.xml` from `0.3.0` to `0.3.1` to use the latest build configuration.
* Updated the `microsphere-spring.version` property in `microsphere-spring-boot-parent/pom.xml` from `0.1.21` to `0.1.22`.

Documentation updates:

* Updated the latest version numbers for both `main` and `1.x` branches in the compatibility table in `README.md` to `0.2.18` and `0.1.18`, respectively.