### PR TITLE
Update microsphere-spring version and README compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Choose the version that matches your Spring Boot generation:
 
 | Branch | Spring Boot Compatibility | Latest Version |
 |--------|---------------------------|----------------|
-| `main` | 3.0.x – 3.5.x, 4.0.x      | `0.2.18`       |
-| `1.x`  | 2.0.x – 2.7.x             | `0.1.18`       |
+| `main` | 3.0.x – 3.5.x, 4.0.x      | `0.2.19`       |
+| `1.x`  | 2.0.x – 2.7.x             | `0.1.19`       |
 
 ### Add Module Dependencies
 

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.22</microsphere-spring.version>
+        <microsphere-spring.version>0.1.23</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>


### PR DESCRIPTION
This pull request updates version numbers to keep dependencies and documentation in sync with the latest releases.

Dependency and documentation updates:

* Updated the `microsphere-spring.version` property in `microsphere-spring-boot-parent/pom.xml` from `0.1.22` to `0.1.23` to use the latest Microsphere Spring version.
* Updated the `README.md` to reflect the latest released versions for the `main` and `1.x` branches (`0.2.19` and `0.1.19`, respectively).