### PR TITLE
Bump parent version and update microsphere-spring dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Choose the version that matches your Spring Boot generation:
 
 | Branch | Spring Boot Compatibility | Latest Version |
 |--------|---------------------------|----------------|
-| `main` | 3.0.x – 3.5.x, 4.0.x      | `0.2.20`       |
-| `1.x`  | 2.0.x – 2.7.x             | `0.1.20`       |
+| `main` | 3.0.x – 3.5.x, 4.0.x      | `0.2.21`       |
+| `1.x`  | 2.0.x – 2.7.x             | `0.1.21`       |
 
 ### Add Module Dependencies
 

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.25</microsphere-spring.version>
+        <microsphere-spring.version>0.1.26</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/microsphere-spring-boot-webflux/src/main/java/io/microsphere/spring/boot/webflux/autoconfigure/condition/ConditionalOnWebFluxAvailable.java
+++ b/microsphere-spring-boot-webflux/src/main/java/io/microsphere/spring/boot/webflux/autoconfigure/condition/ConditionalOnWebFluxAvailable.java
@@ -17,15 +17,9 @@
 
 package io.microsphere.spring.boot.webflux.autoconfigure.condition;
 
-import io.microsphere.spring.web.method.support.HandlerMethodInterceptor;
-import io.microsphere.spring.webflux.annotation.EnableWebFluxExtension;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
-import org.springframework.context.ApplicationContext;
-import org.springframework.web.method.HandlerMethod;
-import org.springframework.web.reactive.DispatcherHandler;
-import reactor.core.publisher.Flux;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -49,13 +43,13 @@ import static org.springframework.boot.autoconfigure.condition.ConditionalOnWebA
 @Retention(RUNTIME)
 @Documented
 @ConditionalOnWebApplication(type = REACTIVE)
-@ConditionalOnClass(value = {
-        Flux.class,                       // Reactor API
-        ApplicationContext.class,         // Spring Context API
-        HandlerMethod.class,              // Spring Web API
-        DispatcherHandler.class,          // Spring WebFlux API
-        HandlerMethodInterceptor.class,   // Microsphere Spring Web API
-        EnableWebFluxExtension.class      // Microsphere Spring WebFlux API
+@ConditionalOnClass(name = {
+        "reactor.core.publisher.Flux",                                         // Reactor API
+        "org.springframework.context.ApplicationContext",                      // Spring Context API
+        "org.springframework.web.method.HandlerMethod",                        // Spring Web API
+        "org.springframework.web.reactive.DispatcherHandler",                  // Spring WebFlux API
+        "io.microsphere.spring.web.method.support.HandlerMethodInterceptor",   // Microsphere Spring Web API
+        "io.microsphere.spring.webflux.annotation.EnableWebFluxExtension"      // Microsphere Spring WebFlux API
 })
 @ConditionalOnProperty(name = MICROSPHERE_SPRING_BOOT_WEBFLUX_ENALBED_PROPERTY_NAME, matchIfMissing = true)
 public @interface ConditionalOnWebFluxAvailable {

--- a/microsphere-spring-boot-webmvc/src/main/java/io/microsphere/spring/boot/webmvc/autoconfigure/condition/ConditionalOnWebMvcAvailable.java
+++ b/microsphere-spring-boot-webmvc/src/main/java/io/microsphere/spring/boot/webmvc/autoconfigure/condition/ConditionalOnWebMvcAvailable.java
@@ -17,16 +17,10 @@
 
 package io.microsphere.spring.boot.webmvc.autoconfigure.condition;
 
-import io.microsphere.spring.web.method.support.HandlerMethodInterceptor;
-import io.microsphere.spring.webmvc.annotation.EnableWebMvcExtension;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
-import org.springframework.context.ApplicationContext;
-import org.springframework.web.method.HandlerMethod;
-import org.springframework.web.servlet.DispatcherServlet;
 
-import javax.servlet.Servlet;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -49,13 +43,13 @@ import static org.springframework.boot.autoconfigure.condition.ConditionalOnWebA
 @Retention(RUNTIME)
 @Documented
 @ConditionalOnWebApplication(type = SERVLET)
-@ConditionalOnClass(value = {
-        Servlet.class,                   // Servlet API
-        ApplicationContext.class,        // Spring Context API
-        HandlerMethod.class,             // Spring Web API
-        DispatcherServlet.class,         // Spring Web MVC API
-        HandlerMethodInterceptor.class,  // Microsphere Spring Web API
-        EnableWebMvcExtension.class      // Microsphere Spring Web MVC API
+@ConditionalOnClass(name = {
+        "javax.servlet.Servlet",                                               // Servlet API
+        "org.springframework.context.ApplicationContext",                      // Spring Context API
+        "org.springframework.web.method.HandlerMethod",                        // Spring Web API
+        "org.springframework.web.servlet.DispatcherServlet",                   // Spring Web MVC API
+        "io.microsphere.spring.web.method.support.HandlerMethodInterceptor",   // Microsphere Spring Web API
+        "io.microsphere.spring.webmvc.annotation.EnableWebMvcExtension"        // Microsphere Spring Web MVC API
 })
 @ConditionalOnProperty(name = MICROSPHERE_SPRING_BOOT_WEBMVC_ENALBED_PROPERTY_NAME, matchIfMissing = true)
 public @interface ConditionalOnWebMvcAvailable {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.3</version>
+        <version>0.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request updates dependency versions in the Maven configuration files to keep the project up-to-date with the latest releases.

Dependency version updates:

* Updated the `microsphere-spring.version` property in `microsphere-spring-boot-parent/pom.xml` from `0.1.25` to `0.1.26` to use the latest version of the Microsphere Spring library.
* Updated the parent `microsphere-build` version in the root `pom.xml` from `0.3.3` to `0.3.4`.