### PR TITLE
Bump Microsphere Spring versions and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Choose the version that matches your Spring Boot generation:
 
 | Branch | Spring Boot Compatibility | Latest Version |
 |--------|---------------------------|----------------|
-| `main` | 3.0.x – 3.5.x, 4.1.x      | `0.2.21`       |
-| `1.x`  | 2.0.x – 2.7.x             | `0.1.21`       |
+| `main` | 3.0.x – 3.5.x, 4.1.x      | `0.2.22`       |
+| `1.x`  | 2.0.x – 2.7.x             | `0.1.22`       |
 
 ### Add Module Dependencies
 

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.26</microsphere-spring.version>
+        <microsphere-spring.version>0.1.27</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>


### PR DESCRIPTION
This pull request updates the project to use the latest compatible versions for both the library and its dependencies. The most important changes are:

Version updates:

* Updated the version references in the `README.md` to reflect the latest releases: `main` branch now uses `0.2.22` and `1.x` branch uses `0.1.22`.
* Bumped the `microsphere-spring.version` property in `microsphere-spring-boot-parent/pom.xml` from `0.1.26` to `0.1.27` to use the latest dependency version.