### PR TITLE
Update microsphere-spring versions and clean up configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Choose the version that matches your Spring Boot generation:
 
 | Branch | Spring Boot Compatibility | Latest Version |
 |--------|---------------------------|----------------|
-| `main` | 3.0.x – 3.5.x, 4.1.x      | `0.2.22`       |
-| `1.x`  | 2.0.x – 2.7.x             | `0.1.22`       |
+| `main` | 3.0.x – 3.5.x, 4.1.x      | `0.2.23`       |
+| `1.x`  | 2.0.x – 2.7.x             | `0.1.23`       |
 
 ### Add Module Dependencies
 

--- a/microsphere-spring-boot-core/src/main/resources/META-INF/config/default/core.properties
+++ b/microsphere-spring-boot-core/src/main/resources/META-INF/config/default/core.properties
@@ -15,3 +15,9 @@ spring.mvc.favicon.enabled = false
 ### Exclude Spring Boot Built-in Auto-Configuration Class
 microsphere.autoconfigure.exclude=\
 org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvcMetricsAutoConfiguration
+
+## Microsphere Spring
+### Microsphere Spring ConfigurableApplicationContextInitializer
+microsphere.spring.event-publishing-bean.enabled = true
+microsphere.spring.listenable-autowire-candidate-resolver.enabled = false
+microsphere.spring.listenable-environment.enabled = false

--- a/microsphere-spring-boot-core/src/main/resources/META-INF/spring.factories
+++ b/microsphere-spring-boot-core/src/main/resources/META-INF/spring.factories
@@ -1,9 +1,6 @@
 # ApplicationContextInitializer
 org.springframework.context.ApplicationContextInitializer=\
-io.microsphere.spring.context.event.EventPublishingBeanInitializer,\
 io.microsphere.spring.boot.report.ConditionEvaluationReportInitializer,\
-io.microsphere.spring.beans.factory.support.ListenableAutowireCandidateResolverInitializer,\
-io.microsphere.spring.core.env.ListenableConfigurableEnvironmentInitializer,\
 io.microsphere.spring.boot.env.config.OriginTrackedConfigurationPropertyInitializer,\
 io.microsphere.spring.boot.context.config.AutoRegistrationBeanInitializer
 

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/env/PropertySourceLoadersTest.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/env/PropertySourceLoadersTest.java
@@ -50,7 +50,7 @@ class PropertySourceLoadersTest {
 
     private static final String TEST_PROPERTY_NAME = "core";
 
-    private static final String TEST_RESOURCE_LOCATION = "classpath:/config/default/core.properties";
+    private static final String TEST_RESOURCE_LOCATION = "classpath:/META-INF/config/default/core.properties";
 
     @Test
     void testGetFileExtensions() {

--- a/microsphere-spring-boot-core/src/test/resources/META-INF/spring.factories
+++ b/microsphere-spring-boot-core/src/test/resources/META-INF/spring.factories
@@ -1,7 +1,3 @@
-# ApplicationContextInitializer
-org.springframework.context.ApplicationContextInitializer=\
-io.microsphere.spring.context.event.EventPublishingBeanInitializer
-
 # PropertySourceLoader
 org.springframework.boot.env.PropertySourceLoader=\
 io.microsphere.spring.boot.env.PropertiesEmptyPropertySourceLoader

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.27</microsphere-spring.version>
+        <microsphere-spring.version>0.1.28</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.29</microsphere-spring.version>
+        <microsphere-spring.version>0.1.30</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.28</microsphere-spring.version>
+        <microsphere-spring.version>0.1.29</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>


### PR DESCRIPTION
This pull request updates the project to use newer versions of dependencies and makes configuration changes to the Spring Boot core module. The most significant updates include bumping the `microsphere-spring` version, updating documentation to reflect new release versions, and adjusting default configuration and initializer registration for improved flexibility.

**Dependency and Version Updates:**

* Bumped the `microsphere-spring` dependency version from `0.1.27` to `0.1.30` in `microsphere-spring-boot-parent/pom.xml`.
* Updated the documented latest versions for both the `main` and `1.x` branches in `README.md` to `0.2.23` and `0.1.23`, respectively.

**Configuration and Initializer Changes:**

* Added new default configuration properties for enabling/disabling specific Microsphere Spring features in `META-INF/config/default/core.properties` (now renamed to `META-INF/config/default/core.properties`). These include toggles for `event-publishing-bean`, `listenable-autowire-candidate-resolver`, and `listenable-environment`.
* Removed several `ApplicationContextInitializer` implementations from `META-INF/spring.factories`, delegating their activation to the new configuration properties instead of always registering them.
* Cleaned up the test `META-INF/spring.factories` by removing the test-specific `ApplicationContextInitializer` entry.