### PR TITLE
Enhance configuration properties handling and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Choose the version that matches your Spring Boot generation:
 
 | Branch | Spring Boot Compatibility | Latest Version |
 |--------|---------------------------|----------------|
-| `main` | 3.0.x – 3.5.x, 4.1.x      | `0.2.24`       |
-| `1.x`  | 2.0.x – 2.7.x             | `0.1.24`       |
+| `main` | 3.0.x – 3.5.x, 4.1.x      | `0.2.26`       |
+| `1.x`  | 2.0.x – 2.7.x             | `0.1.26`       |
 
 ### Add Module Dependencies
 

--- a/microsphere-spring-boot-compatible/src/main/java/org/springframework/boot/context/properties/ConstructorBinding.java
+++ b/microsphere-spring-boot-compatible/src/main/java/org/springframework/boot/context/properties/ConstructorBinding.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.context.properties;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that can be used to indicate that configuration properties should be bound
+ * using constructor arguments rather than by calling setters. Can be added at the type
+ * level (if there is an unambiguous constructor) or on the actual constructor to use.
+ * <p>
+ * Note: To use constructor binding the class must be enabled using
+ * {@link EnableConfigurationProperties @EnableConfigurationProperties} or configuration
+ * property scanning. Constructor binding cannot be used with beans that are created by
+ * the regular Spring mechanisms (e.g.
+ * {@link org.springframework.stereotype.Component @Component} beans, beans created via
+ * {@link org.springframework.context.annotation.Bean @Bean} methods or beans loaded using
+ * {@link org.springframework.context.annotation.Import @Import}).
+ *
+ * @author Phillip Webb
+ * @since 2.2.0
+ * @see ConfigurationProperties
+ */
+@Target({ ElementType.TYPE, ElementType.CONSTRUCTOR })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ConstructorBinding {
+
+}

--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
@@ -195,7 +195,7 @@ class ConfigurationPropertiesBeanContext {
             for (Map.Entry<ConfigurationPropertyName, ConfigurationPropertiesBeanProperty> entry : this.beanProperties.entrySet()) {
                 ConfigurationPropertyName propertyName = entry.getKey();
                 ConfigurationPropertiesBeanProperty property = entry.getValue();
-                beanInfo.add(format("Configuration Property Name : '{}' => Java Bean Property : {}", propertyName, property));
+                beanInfo.add(format("Configuration Property Name : '{}' => Bean Property : {}", propertyName, property));
             }
             logger.trace("The ConfigurationPropertiesBeanContext is initialized, bean type : {} , prefix : '{}' , properties : {}",
                     this.beanType, this.prefix, beanInfo);
@@ -211,7 +211,7 @@ class ConfigurationPropertiesBeanContext {
     private void initBeanProperties(ResolvableType beanType, ConfigurationPropertyName prefixName, String nestedPath) {
         Class<?> beanClass = beanType.getRawClass();
         if (isCandidateClass(beanClass)) {
-            Constructor<?> bindConstructor = getBindConstructor(beanType);
+            Constructor<?> bindConstructor = this.bindConstructor;
             if (bindConstructor == null) {
                 PropertyDescriptor[] descriptors = getPropertyDescriptors(beanClass);
                 initBeanProperties(beanType, descriptors, prefixName, nestedPath);
@@ -457,8 +457,8 @@ class ConfigurationPropertiesBeanContext {
             // Set the new value if it is different from the old value
             beanProperty.setValue(actualNewValue);
             changed = true;
-            if (logger.isInfoEnabled()) {
-                logger.info("Set property [path : '{}'] from '{}' to '{}'(actual : '{}') , Bean Property : {}",
+            if (logger.isTraceEnabled()) {
+                logger.trace("Set property [path : '{}'] from '{}' to '{}'(actual : '{}') , Bean Property : {}",
                         beanProperty.getName(), oldValue, newValue, actualNewValue, beanProperty);
             }
         }

--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
@@ -160,15 +160,6 @@ class ConfigurationPropertiesBeanContext {
     }
 
     /**
-     * Is the bean a constructor binding bean ?
-     *
-     * @return if the bean is a constructor binding bean , return {@code true} , else return {@code false}
-     */
-    boolean isConstructorBindingBean() {
-        return this.bindConstructor != null;
-    }
-
-    /**
      * Get the prefix
      *
      * @return the prefix

--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
@@ -24,8 +24,11 @@ import io.microsphere.reflect.MemberUtils;
 import io.microsphere.spring.boot.context.properties.bind.util.BindUtils;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeanWrapperImpl;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.ConfigurationProperty;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -44,13 +47,14 @@ import static io.microsphere.collection.MapUtils.newHashMap;
 import static io.microsphere.constants.SeparatorConstants.LINE_SEPARATOR;
 import static io.microsphere.constants.SymbolConstants.DOT;
 import static io.microsphere.constants.SymbolConstants.DOT_CHAR;
-import static io.microsphere.lang.function.ThrowableSupplier.execute;
 import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.reflect.FieldUtils.findAllDeclaredFields;
+import static io.microsphere.reflect.FieldUtils.findField;
 import static io.microsphere.reflect.MethodUtils.invokeMethod;
 import static io.microsphere.spring.boot.context.properties.source.util.ConfigurationPropertyUtils.getParent;
-import static io.microsphere.spring.boot.context.properties.source.util.ConfigurationPropertyUtils.newConfigurationPropertiesBeanProperty;
 import static io.microsphere.spring.boot.context.properties.source.util.ConfigurationPropertyUtils.toDashedForm;
+import static io.microsphere.spring.boot.context.properties.util.ConfigurationPropertiesUtils.CONFIGURATION_PROPERTIES_CLASS;
+import static io.microsphere.spring.core.annotation.AnnotationUtils.getAnnotationAttributes;
 import static io.microsphere.text.FormatUtils.format;
 import static io.microsphere.util.Assert.assertNotBlank;
 import static io.microsphere.util.Assert.assertNotNull;
@@ -58,10 +62,11 @@ import static io.microsphere.util.ClassUtils.isConcreteClass;
 import static io.microsphere.util.StringUtils.isBlank;
 import static io.microsphere.util.StringUtils.replace;
 import static java.util.Objects.deepEquals;
+import static org.springframework.beans.BeanUtils.copyProperties;
 import static org.springframework.beans.BeanUtils.getPropertyDescriptors;
+import static org.springframework.beans.BeanUtils.instantiateClass;
 import static org.springframework.boot.context.properties.bind.Bindable.of;
 import static org.springframework.boot.context.properties.source.ConfigurationPropertyName.of;
-import static org.springframework.core.ResolvableType.forInstance;
 import static org.springframework.util.ClassUtils.isAssignableValue;
 import static org.springframework.util.ClassUtils.isPrimitiveOrWrapper;
 
@@ -79,7 +84,12 @@ class ConfigurationPropertiesBeanContext {
     private static final Logger logger = getLogger(ConfigurationPropertiesBeanContext.class);
 
     @Nonnull
+    private final String beanName;
+
+    @Nonnull
     private final ResolvableType beanType;
+
+    private final Constructor<?> bindConstructor;
 
     @Nonnull
     private final AnnotationAttributes annotationAttributes;
@@ -100,32 +110,84 @@ class ConfigurationPropertiesBeanContext {
     @Nullable
     private volatile Object initializedBean;
 
+    @Nullable
     private volatile BeanWrapper beanWrapper;
 
     /**
      * Constructor
      *
+     * @param beanName             the bean name
      * @param beanType             the bean type
      * @param annotationAttributes the {@link AnnotationAttributes} of {@link ConfigurationProperties}
-     * @param prefix               {@link ConfigurationProperties#prefix() the prefix}
      * @param context              {@link ConfigurableApplicationContext}
      * @throws IllegalArgumentException If <code>beanClass</code> or <code>annotation</code> or <code>context</code> argument is null,
      *                                  or the <code>prefix</code> is blank
      */
-    ConfigurationPropertiesBeanContext(ResolvableType beanType, AnnotationAttributes annotationAttributes, String prefix,
+    ConfigurationPropertiesBeanContext(String beanName, ResolvableType beanType, AnnotationAttributes annotationAttributes,
                                        ConfigurableApplicationContext context) throws IllegalArgumentException {
+        assertNotBlank(beanName, () -> "The 'beanName' must not be null!");
         assertNotNull(beanType, () -> "The 'beanType' must not be null!");
         assertNotNull(annotationAttributes, () -> "The 'annotationAttributes' must not be null!");
-        assertNotBlank(prefix, () -> "The 'prefix' must not be black!");
         assertNotNull(context, () -> "The 'assertNotNull' must not be null!");
+        this.beanName = beanName;
         this.beanType = beanType;
+        this.bindConstructor = getBindConstructor(beanType);
         this.annotationAttributes = annotationAttributes;
-        this.prefix = prefix;
+        this.prefix = annotationAttributes.getString("prefix");
         this.context = context;
         this.beanProperties = newHashMap();
     }
 
-    void initialize(Object bean) {
+    /**
+     * Get the bean name
+     *
+     * @return the bean name
+     */
+    @Nonnull
+    String getBeanName() {
+        return this.beanName;
+    }
+
+    /**
+     * Get the bean type
+     *
+     * @return the bean type
+     */
+    @Nonnull
+    ResolvableType getBeanType() {
+        return this.beanType;
+    }
+
+    /**
+     * Is the bean a constructor binding bean ?
+     *
+     * @return if the bean is a constructor binding bean , return {@code true} , else return {@code false}
+     */
+    boolean isConstructorBindingBean() {
+        return this.bindConstructor != null;
+    }
+
+    /**
+     * Get the prefix
+     *
+     * @return the prefix
+     */
+    @Nonnull
+    String getPrefix() {
+        return this.prefix;
+    }
+
+    /**
+     * Get the bean class
+     *
+     * @return the bean class
+     */
+    @Nonnull
+    Class<?> getBeanClass() {
+        return getBeanType().getRawClass();
+    }
+
+    void setBean(Object bean) {
         if (!this.beanType.isInstance(bean)) {
             if (logger.isWarnEnabled()) {
                 Class<?> beanClass = bean.getClass();
@@ -135,9 +197,7 @@ class ConfigurationPropertiesBeanContext {
             return;
         }
         this.initializedBean = bean;
-        this.beanWrapper = new BeanWrapperImpl(bean);
-        initBeanProperties(bean);
-
+        initBeanProperties();
         if (logger.isTraceEnabled()) {
             StringJoiner beanInfo = new StringJoiner(LINE_SEPARATOR);
             for (Map.Entry<ConfigurationPropertyName, ConfigurationPropertiesBeanProperty> entry : this.beanProperties.entrySet()) {
@@ -150,10 +210,10 @@ class ConfigurationPropertiesBeanContext {
         }
     }
 
-    private void initBeanProperties(Object bean) {
-        String prefix = this.prefix;
-        ConfigurationPropertyName prefixName = of(prefix);
-        initBeanProperties(forInstance(bean), prefixName, null);
+    private void initBeanProperties() {
+        Object bean = getBean();
+        this.beanWrapper = new BeanWrapperImpl(bean);
+        initBeanProperties(this.beanType, of(this.prefix), null);
     }
 
     private void initBeanProperties(ResolvableType beanType, ConfigurationPropertyName prefixName, String nestedPath) {
@@ -168,6 +228,32 @@ class ConfigurationPropertiesBeanContext {
                 initBeanProperties(beanType, fields, prefixName, nestedPath);
             }
         }
+    }
+
+    /**
+     * Binds the property values of the bean after {@link Binder#bind(String, Bindable) binding}.
+     *
+     * @see Binder#bind(String, Bindable)
+     */
+    void bindPropertyValues() {
+        this.beanProperties.values().forEach(this::bindPropertyValue);
+    }
+
+    boolean bindPropertyValue(ConfigurationPropertiesBeanProperty beanProperty) {
+        String propertyPath = beanProperty.getName();
+        Object newValue = getPropertyValue(propertyPath);
+        return setPropertyValue(beanProperty, beanProperty.getValue(), newValue, false);
+    }
+
+    Object getBean() {
+        Object bean = this.initializedBean;
+        if (bean == null) {
+            // Get the bean from the Spring context by its name
+            String beanName = getBeanName();
+            bean = this.context.getBean(beanName, getBeanClass());
+            this.initializedBean = bean;
+        }
+        return bean;
     }
 
     private Constructor<?> getBindConstructor(ResolvableType beanType) {
@@ -186,16 +272,16 @@ class ConfigurationPropertiesBeanContext {
             String propertyPath = buildPropertyPath(propertyName, nestedPath);
             ConfigurationPropertyName configurationPropertyName = prefixName.append(toDashedForm(propertyName));
             ConfigurationPropertiesBeanProperty property = this.beanProperties.computeIfAbsent(configurationPropertyName, name -> {
-                ConfigurationPropertiesBeanProperty newProperty = new ConfigurationPropertiesBeanProperty();
+                ConfigurationPropertiesBeanProperty newBeanProperty = new ConfigurationPropertiesBeanProperty();
                 Method getter = descriptor.getReadMethod();
                 Method setter = descriptor.getWriteMethod();
                 Object value = getPropertyValue(nestedPath, propertyPath);
-                newProperty.setDeclaringClassType(beanType);
-                newProperty.setName(propertyPath);
-                newProperty.setGetter(getter);
-                newProperty.setSetter(setter);
-                newProperty.setValue(value);
-                return newProperty;
+                newBeanProperty.setDeclaringClassType(beanType);
+                newBeanProperty.setName(propertyPath);
+                newBeanProperty.setGetter(getter);
+                newBeanProperty.setSetter(setter);
+                newBeanProperty.setValue(value);
+                return newBeanProperty;
             });
             initBeanProperties(property.getType(), configurationPropertyName, propertyPath);
         }
@@ -215,12 +301,17 @@ class ConfigurationPropertiesBeanContext {
     }
 
     Object getPropertyValue(String propertyPath) {
-        return execute(() -> this.beanWrapper.getPropertyValue(propertyPath), e -> {
-            if (logger.isTraceEnabled()) {
-                logger.trace("Failed to get property value for property path : {}", propertyPath, e);
-            }
-            return null;
-        });
+        return getPropertyValue(this.beanWrapper, propertyPath);
+    }
+
+    Object getPropertyValue(BeanWrapper beanWrapper, String propertyPath) {
+        if (beanWrapper != null && beanWrapper.isReadableProperty(propertyPath)) {
+            return clone(beanWrapper.getPropertyValue(propertyPath));
+        }
+        if (logger.isTraceEnabled()) {
+            logger.trace("Can't get property value for property path : '{}' in the Bean[{}]", propertyPath, getBeanType());
+        }
+        return null;
     }
 
     private void initBeanProperties(ResolvableType beanType, Set<Field> fields, ConfigurationPropertyName prefixName, String nestedPath) {
@@ -234,24 +325,24 @@ class ConfigurationPropertiesBeanContext {
         propertyName = replace(propertyName, "_", "");
         ConfigurationPropertyName configurationPropertyName = prefixName.append(toDashedForm(propertyName));
         String propertyPath = buildPropertyPath(field.getName(), nestedPath);
-        ConfigurationPropertiesBeanProperty property = this.beanProperties.computeIfAbsent(configurationPropertyName, name -> {
+        ConfigurationPropertiesBeanProperty beanProperty = this.beanProperties.computeIfAbsent(configurationPropertyName, name -> {
             ConfigurationPropertiesBeanProperty newProperty = new ConfigurationPropertiesBeanProperty();
             newProperty.setDeclaringClassType(beanType);
             return newProperty;
         });
         Object value = readFieldValue(field, nestedPath);
-        property.setName(propertyPath);
-        property.setField(field);
-        property.setValue(value);
-        initBeanProperties(property.getType(), configurationPropertyName, propertyPath);
+        beanProperty.setName(propertyPath);
+        beanProperty.setField(field);
+        beanProperty.setValue(value);
+        initBeanProperties(beanProperty.getType(), configurationPropertyName, propertyPath);
     }
 
     Object readFieldValue(Field field, @Nullable String nestedPath) {
-        Object instance = getInstance(this.initializedBean, nestedPath);
+        Object instance = getInstance(getBean(), nestedPath);
         if (instance == null) {
             return null;
         }
-        return FieldUtils.getFieldValue(instance, field);
+        return getFieldValue(instance, field);
     }
 
     static Object getInstance(Object bean, @Nullable String nestedPath) {
@@ -272,13 +363,18 @@ class ConfigurationPropertiesBeanContext {
     }
 
     static Object getFieldValue(Object instance, String fieldName) {
-        Object fieldValue = FieldUtils.getFieldValue(instance, fieldName);
+        Field field = findField(instance, fieldName);
+        return getFieldValue(instance, field);
+    }
+
+    static Object getFieldValue(Object instance, Field field) {
+        Object fieldValue = FieldUtils.getFieldValue(instance, field);
         if (fieldValue == null) {
             if (logger.isTraceEnabled()) {
-                logger.trace("The field[name : '{}'] value can't be found in the instance : '{}'", fieldName, instance);
+                logger.trace("The field['{}'] value can't be found in the instance : '{}'", field, instance);
             }
         }
-        return fieldValue;
+        return clone(fieldValue);
     }
 
     static String buildPropertyPath(String propertyName, @Nullable String nestedPath) {
@@ -328,74 +424,126 @@ class ConfigurationPropertiesBeanContext {
         return isConcreteClass(beanClass);
     }
 
-    ConfigurationPropertiesBeanProperty initProperty(ConfigurationPropertyName propertyName, Bindable<?> bindable) {
-        if (propertyName.isLastElementIndexed()) {
-            propertyName = getParent(propertyName);
-        }
-        return this.beanProperties.computeIfAbsent(propertyName, n -> newConfigurationPropertiesBeanProperty(bindable));
-    }
-
-    ConfigurationPropertiesBeanProperty getProperty(ConfigurationPropertyName propertyName) {
-        ConfigurationPropertiesBeanProperty property = this.beanProperties.get(propertyName);
-        if (property == null) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("No ConfigurationPropertiesBeanProperty was found by the configuration property name : '{}'", propertyName);
-            }
-        }
-        return property;
-    }
-
-    void setProperty(ConfigurationProperty property, Object newValue, boolean publishedEvent) {
+    void setProperty(ConfigurationProperty property, Object newValue) {
         ConfigurationPropertyName name = property.getName();
-
-        ConfigurationPropertiesBeanProperty configurationPropertiesBeanProperty = null;
+        ConfigurationPropertiesBeanProperty beanProperty = null;
 
         if (name.isLastElementIndexed()) { // name is numerically indexed or non-numerically indexed
             name = getParent(name);
         }
 
-        configurationPropertiesBeanProperty = getProperty(name);
+        beanProperty = getProperty(name);
         // name is not indexed or Map-typed
-        if (configurationPropertiesBeanProperty == null) { // name is Map-typed
+        if (beanProperty == null) { // name is Map-typed
             name = getParent(name);
-            configurationPropertiesBeanProperty = getProperty(name);
+            beanProperty = getProperty(name);
         }
 
-        if (configurationPropertiesBeanProperty == null) {
+        if (beanProperty == null) {
             return;
         }
 
-        ResolvableType propertyType = configurationPropertiesBeanProperty.getType();
+        ResolvableType propertyType = beanProperty.getType();
         Class<?> propertyClass = propertyType.resolve();
         if (isAssignableValue(propertyClass, newValue)) {
-            Object oldValue = configurationPropertiesBeanProperty.getValue();
-            if (!deepEquals(oldValue, newValue)) {
-                setProperty(property, configurationPropertiesBeanProperty, name, oldValue, newValue, publishedEvent);
+            Object oldValue = beanProperty.getValue();
+            if (setPropertyValue(beanProperty, oldValue, newValue, true)) {
+                publishEvent(property, beanProperty, oldValue, newValue);
             }
         }
     }
 
-    void setProperty(ConfigurationProperty property, ConfigurationPropertiesBeanProperty configurationPropertiesBeanProperty,
-                     ConfigurationPropertyName name, Object oldValue, Object newValue, boolean publishedEvent) {
-        if (newValue instanceof Cloneable) {
-            // Use clone object to avoid the newValue is changed by other code, which will cause the oldValue and newValue are same
-            newValue = invokeMethod(newValue, "clone");
+    boolean setPropertyValue(ConfigurationPropertiesBeanProperty beanProperty, Object oldValue, Object newValue,
+                             boolean resolved) {
+        boolean changed = false;
+        Object actualNewValue = resolveNewPropertyValue(beanProperty, newValue, resolved);
+        if (!deepEquals(oldValue, actualNewValue)) {
+            // Set the new value if it is different from the old value
+            beanProperty.setValue(actualNewValue);
+            changed = true;
+            if (logger.isInfoEnabled()) {
+                logger.info("Set property [path : '{}'] from '{}' to '{}'(actual : '{}') , Bean Property : {}",
+                        beanProperty.getName(), oldValue, newValue, actualNewValue, beanProperty);
+            }
         }
-        configurationPropertiesBeanProperty.setValue(newValue);
-        if (logger.isInfoEnabled()) {
-            logger.info("Set property [name : '{}'] from '{}' to '{}' , ConfigurationPropertiesBeanProperty : {} , Source : {}",
-                    name, oldValue, newValue, configurationPropertiesBeanProperty, property);
-        }
-        if (publishedEvent) {
-            publishEvent(property, configurationPropertiesBeanProperty, oldValue, newValue);
-        }
+        return changed;
     }
 
-    void publishEvent(ConfigurationProperty property, ConfigurationPropertiesBeanProperty configurationPropertiesBeanProperty,
+    Object resolveNewPropertyValue(ConfigurationPropertiesBeanProperty beanProperty, Object newValue, boolean resolved) {
+        if (resolved) {
+            Object clonedBean = cloneBean();
+            BeanWrapper clonedBeanWrapper = new BeanWrapperImpl(clonedBean);
+            String propertyPath = beanProperty.getName();
+            if (clonedBeanWrapper.isWritableProperty(propertyPath)) {
+                clonedBeanWrapper.setPropertyValue(propertyPath, newValue);
+                return getPropertyValue(clonedBeanWrapper, propertyPath);
+            }
+        }
+        return newValue;
+    }
+
+    ConfigurationPropertiesBeanProperty getProperty(ConfigurationPropertyName propertyName) {
+        ConfigurationPropertiesBeanProperty property = this.beanProperties.get(propertyName);
+        if (property == null) {
+            if (logger.isTraceEnabled()) {
+                logger.trace("No ConfigurationPropertiesBeanProperty was found by the configuration property name : '{}'", propertyName);
+            }
+        }
+        return property;
+    }
+
+    void publishEvent(ConfigurationProperty property, ConfigurationPropertiesBeanProperty beanProperty,
                       Object oldValue, Object newValue) {
-        String propertyName = configurationPropertiesBeanProperty.getName();
-        ResolvableType propertyType = configurationPropertiesBeanProperty.getType();
-        this.context.publishEvent(new ConfigurationPropertiesBeanPropertyChangedEvent(initializedBean, propertyName,
+        String propertyName = beanProperty.getName();
+        ResolvableType propertyType = beanProperty.getType();
+        this.context.publishEvent(new ConfigurationPropertiesBeanPropertyChangedEvent(getBean(), propertyName,
                 propertyType, oldValue, newValue, property));
+    }
+
+
+    Object cloneBean() {
+        Object bean = getBean();
+        Object clnoedBean = null;
+        Class<?> beanClass = getBeanClass();
+        Constructor<?> bindConstructor = this.bindConstructor;
+        if (bindConstructor == null) {
+            clnoedBean = instantiateClass(beanClass);
+            copyProperties(bean, clnoedBean);
+        } else {
+            clnoedBean = bean;
+        }
+        return clnoedBean;
+    }
+
+    /**
+     * Clone object to avoid the newValue is changed by other code, which will cause the oldValue and newValue are same.
+     *
+     * @param value the value to be cloned
+     * @return the cloned value
+     */
+    static Object clone(Object value) {
+        if (value instanceof Cloneable) {
+            value = invokeMethod(value, "clone");
+        }
+        return value;
+    }
+
+    static Map<String, ConfigurationPropertiesBeanContext> buildConfigurationPropertiesBeanContexts
+            (ConfigurableApplicationContext context) {
+        ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+        String[] beanDefinitionNames = beanFactory.getBeanDefinitionNames();
+        Map<String, ConfigurationPropertiesBeanContext> beanContexts = newHashMap();
+        for (String beanName : beanDefinitionNames) {
+            BeanDefinition beanDefinition = beanFactory.getMergedBeanDefinition(beanName);
+            ResolvableType beanType = beanDefinition.getResolvableType();
+            Class<?> beanClass = beanType.resolve();
+            ConfigurationProperties annotation = beanClass == null ? null : beanClass.getAnnotation(CONFIGURATION_PROPERTIES_CLASS);
+            if (annotation != null) {
+                AnnotationAttributes annotationAttributes = getAnnotationAttributes(annotation);
+                ConfigurationPropertiesBeanContext beanContext = new ConfigurationPropertiesBeanContext(beanName, beanType, annotationAttributes, context);
+                beanContexts.put(beanContext.getPrefix(), beanContext);
+            }
+        }
+        return beanContexts;
     }
 }

--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
@@ -24,8 +24,8 @@ import io.microsphere.reflect.MemberUtils;
 import io.microsphere.spring.boot.context.properties.bind.util.BindUtils;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeanWrapperImpl;
-import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
@@ -51,6 +51,7 @@ import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.reflect.FieldUtils.findAllDeclaredFields;
 import static io.microsphere.reflect.FieldUtils.findField;
 import static io.microsphere.reflect.MethodUtils.invokeMethod;
+import static io.microsphere.spring.beans.factory.config.BeanDefinitionUtils.getResolvableType;
 import static io.microsphere.spring.boot.context.properties.source.util.ConfigurationPropertyUtils.getParent;
 import static io.microsphere.spring.boot.context.properties.source.util.ConfigurationPropertyUtils.toDashedForm;
 import static io.microsphere.spring.boot.context.properties.util.ConfigurationPropertiesUtils.CONFIGURATION_PROPERTIES_CLASS;
@@ -534,8 +535,8 @@ class ConfigurationPropertiesBeanContext {
         String[] beanDefinitionNames = beanFactory.getBeanDefinitionNames();
         Map<String, ConfigurationPropertiesBeanContext> beanContexts = newHashMap();
         for (String beanName : beanDefinitionNames) {
-            BeanDefinition beanDefinition = beanFactory.getMergedBeanDefinition(beanName);
-            ResolvableType beanType = beanDefinition.getResolvableType();
+            RootBeanDefinition beanDefinition = (RootBeanDefinition) beanFactory.getMergedBeanDefinition(beanName);
+            ResolvableType beanType = getResolvableType(beanDefinition);
             Class<?> beanClass = beanType.resolve();
             ConfigurationProperties annotation = beanClass == null ? null : beanClass.getAnnotation(CONFIGURATION_PROPERTIES_CLASS);
             if (annotation != null) {

--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
@@ -228,7 +228,11 @@ class ConfigurationPropertiesBeanContext {
      * @see Binder#bind(String, Bindable)
      */
     void bindPropertyValues() {
-        this.beanProperties.values().forEach(this::bindPropertyValue);
+        if (this.bindConstructor == null) {
+            this.beanProperties.values().forEach(this::bindPropertyValue);
+        } else {
+            initBeanProperties();
+        }
     }
 
     boolean bindPropertyValue(ConfigurationPropertiesBeanProperty beanProperty) {

--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanProperty.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanProperty.java
@@ -110,6 +110,13 @@ public class ConfigurationPropertiesBeanProperty {
     }
 
     public String getName() {
+        if (this.name == null) {
+            return resolveName();
+        }
+        return this.name;
+    }
+
+    String resolveName() {
         Field field = this.field;
         if (field != null) {
             return field.getName();
@@ -142,6 +149,6 @@ public class ConfigurationPropertiesBeanProperty {
 
     @Override
     public String toString() {
-        return format("{} {}.{} = {}", getType(), getDeclaringClassType(), getName(), getValue());
+        return format("{} {}.{} = {}", getType(), getDeclaringClassType(), resolveName(), getValue());
     }
 }

--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/EventPublishingConfigurationPropertiesBeanPropertyChangedListener.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/EventPublishingConfigurationPropertiesBeanPropertyChangedListener.java
@@ -19,9 +19,8 @@ package io.microsphere.spring.boot.context.properties.bind;
 import io.microsphere.annotation.Nullable;
 import io.microsphere.logging.Logger;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.SmartInitializingSingleton;
-import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.BindContext;
 import org.springframework.boot.context.properties.bind.Bindable;
@@ -30,21 +29,16 @@ import org.springframework.boot.context.properties.source.ConfigurationPropertyN
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.core.ResolvableType;
-import org.springframework.core.annotation.AnnotationAttributes;
 
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static io.microsphere.collection.MapUtils.newHashMap;
 import static io.microsphere.logging.LoggerFactory.getLogger;
+import static io.microsphere.spring.boot.context.properties.bind.ConfigurationPropertiesBeanContext.buildConfigurationPropertiesBeanContexts;
 import static io.microsphere.spring.boot.context.properties.bind.util.BindUtils.isBoundProperty;
 import static io.microsphere.spring.boot.context.properties.bind.util.BindUtils.isConfigurationPropertiesBean;
 import static io.microsphere.spring.boot.context.properties.source.util.ConfigurationPropertyUtils.getPrefix;
-import static io.microsphere.spring.boot.context.properties.util.ConfigurationPropertiesUtils.CONFIGURATION_PROPERTIES_CLASS;
-import static io.microsphere.spring.boot.context.properties.util.ConfigurationPropertiesUtils.findConfigurationProperties;
-import static io.microsphere.spring.core.annotation.AnnotationUtils.getAnnotationAttributes;
-import static org.springframework.util.Assert.isInstanceOf;
+import static io.microsphere.spring.context.ApplicationContextUtils.asConfigurableApplicationContext;
 
 /**
  * A {@link BindListener} implementation of {@link ConfigurationProperties @ConfigurationProperties} Bean to publish
@@ -56,11 +50,9 @@ import static org.springframework.util.Assert.isInstanceOf;
  * @see ConfigurationPropertiesBeanPropertyChangedEvent
  * @since 1.0.0
  */
-public class EventPublishingConfigurationPropertiesBeanPropertyChangedListener implements BindListener, BeanFactoryPostProcessor, ApplicationContextAware, SmartInitializingSingleton {
+public class EventPublishingConfigurationPropertiesBeanPropertyChangedListener implements BindListener, ApplicationContextAware, InitializingBean, SmartInitializingSingleton {
 
     private static final Logger logger = getLogger(EventPublishingConfigurationPropertiesBeanPropertyChangedListener.class);
-
-    private static final Class<ConfigurableApplicationContext> CONFIGURABLE_APPLICATION_CONTEXT_CLASS = ConfigurableApplicationContext.class;
 
     private Map<String, ConfigurationPropertiesBeanContext> beanContexts;
 
@@ -95,7 +87,9 @@ public class EventPublishingConfigurationPropertiesBeanPropertyChangedListener i
      */
     @Override
     public void onSuccess(ConfigurationPropertyName name, Bindable<?> target, BindContext context, Object result) {
-        setConfigurationPropertiesBeanProperty(name, target, context, result);
+        if (isBound()) {
+            setConfigurationPropertiesBeanProperty(name, target, context, result);
+        }
     }
 
     void initConfigurationPropertiesBeanContext(ConfigurationPropertyName name, Bindable<?> target, BindContext context) {
@@ -112,14 +106,12 @@ public class EventPublishingConfigurationPropertiesBeanPropertyChangedListener i
                             name, target, context.getDepth());
                 }
             } else {
-                configurationPropertiesBeanContext.initialize(bean);
+                configurationPropertiesBeanContext.setBean(bean);
                 if (logger.isTraceEnabled()) {
                     logger.trace("The ConfigurationPropertiesBean binding is finished[name : '{}' , target : {} , depth : {} , bean : '{}']",
                             name, target, context.getDepth(), bean);
                 }
             }
-        } else {
-            configurationPropertiesBeanContext.initProperty(name, target);
         }
     }
 
@@ -127,8 +119,7 @@ public class EventPublishingConfigurationPropertiesBeanPropertyChangedListener i
     private ConfigurationPropertiesBeanContext getConfigurationPropertiesBeanContext(ConfigurationPropertyName name,
                                                                                      Bindable<?> target, BindContext context) {
         String prefix = getPrefix(name, context);
-        ConfigurationPropertiesBeanContext configurationPropertiesBeanContext = this.beanContexts.computeIfAbsent(prefix,
-                p -> newConfigurationPropertiesBeanContext(target, p));
+        ConfigurationPropertiesBeanContext configurationPropertiesBeanContext = this.beanContexts.get(prefix);
         if (configurationPropertiesBeanContext == null) {
             if (logger.isWarnEnabled()) {
                 logger.warn("No ConfigurationPropertiesBeanContext was found[name : '{}' , target : {} , depth : {}]",
@@ -136,29 +127,6 @@ public class EventPublishingConfigurationPropertiesBeanPropertyChangedListener i
             }
         }
         return configurationPropertiesBeanContext;
-    }
-
-    ConfigurationPropertiesBeanContext newConfigurationPropertiesBeanContext(Bindable<?> target, String prefix) {
-        ConfigurationProperties annotation = findConfigurationProperties(target);
-        if (annotation == null) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("The ConfigurationPropertiesBeanContext is not created caused by the missing @ConfigurationProperties annotation, target : {}",
-                        target);
-            }
-            return null;
-        }
-        AnnotationAttributes annotationAttributes = getAnnotationAttributes(annotation);
-        String actualPrefix = annotationAttributes.getString("prefix");
-        if (!prefix.equalsIgnoreCase(actualPrefix)) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("The ConfigurationPropertiesBeanContext is not created caused by the mismatched prefix[expected : '{}' , actual : '{}'], target : {}",
-                        prefix, actualPrefix, target);
-            }
-            return null;
-        }
-
-        ResolvableType beanType = target.getType();
-        return new ConfigurationPropertiesBeanContext(beanType, annotationAttributes, prefix, this.context);
     }
 
     /**
@@ -177,7 +145,7 @@ public class EventPublishingConfigurationPropertiesBeanPropertyChangedListener i
             if (configurationPropertiesBeanContext == null) {
                 return;
             }
-            configurationPropertiesBeanContext.setProperty(property, result, isBound());
+            configurationPropertiesBeanContext.setProperty(property, result);
             if (logger.isTraceEnabled()) {
                 logger.trace("binding Bean property is finished , configuration property : '{}' , type : '{}' , depth : {} , result : '{}'", property, target.getType(), context.getDepth(), result);
             }
@@ -185,79 +153,36 @@ public class EventPublishingConfigurationPropertiesBeanPropertyChangedListener i
     }
 
     /**
-     * Post-processes the bean factory to initialize the internal map of
-     * {@link ConfigurationPropertiesBeanContext} instances for all
-     * {@link ConfigurationProperties @ConfigurationProperties} beans.
-     *
-     * <h3>Example Usage</h3>
-     * <pre>{@code
-     *   EventPublishingConfigurationPropertiesBeanPropertyChangedListener listener =
-     *       new EventPublishingConfigurationPropertiesBeanPropertyChangedListener();
-     *   listener.postProcessBeanFactory(beanFactory);
-     * }</pre>
-     *
-     * @param beanFactory the bean factory to post-process
-     * @throws BeansException if an error occurs
-     */
-    @Override
-    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
-        initConfigurationPropertiesBeanContexts(beanFactory);
-    }
-
-    private void initConfigurationPropertiesBeanContexts(ConfigurableListableBeanFactory beanFactory) {
-        String[] beanNames = beanFactory.getBeanNamesForAnnotation(CONFIGURATION_PROPERTIES_CLASS);
-        int beanCount = beanNames.length;
-        this.beanContexts = newHashMap(beanCount);
-    }
-
-    /**
      * Sets the {@link ApplicationContext}, which must be a {@link ConfigurableApplicationContext},
      * for publishing property change events.
-     *
-     * <h3>Example Usage</h3>
-     * <pre>{@code
-     *   EventPublishingConfigurationPropertiesBeanPropertyChangedListener listener =
-     *       new EventPublishingConfigurationPropertiesBeanPropertyChangedListener();
-     *   listener.setApplicationContext(applicationContext);
-     * }</pre>
      *
      * @param context the application context, must be a {@link ConfigurableApplicationContext}
      * @throws BeansException if the context is not a {@link ConfigurableApplicationContext}
      */
     @Override
     public void setApplicationContext(ApplicationContext context) throws BeansException {
-        Class<ConfigurableApplicationContext> expectedType = CONFIGURABLE_APPLICATION_CONTEXT_CLASS;
-        isInstanceOf(expectedType, context, "The 'context' argument is not an instance of " + expectedType.getName());
-        this.context = expectedType.cast(context);
+        this.context = asConfigurableApplicationContext(context);
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        this.beanContexts = buildConfigurationPropertiesBeanContexts(this.context);
     }
 
     /**
      * Called after all singleton beans have been instantiated, marking that initial binding
      * is complete. Subsequent binding operations will detect and publish property changes.
-     *
-     * <h3>Example Usage</h3>
-     * <pre>{@code
-     *   EventPublishingConfigurationPropertiesBeanPropertyChangedListener listener = ...;
-     *   // Called automatically by the Spring container
-     *   listener.afterSingletonsInstantiated();
-     *   assertTrue(listener.isBound());
-     * }</pre>
      */
     @Override
     public void afterSingletonsInstantiated() {
+        for (ConfigurationPropertiesBeanContext beanContext : this.beanContexts.values()) {
+            beanContext.bindPropertyValues();
+        }
         bound = true;
     }
 
     /**
      * Returns whether the initial binding of all singleton beans has been completed.
-     *
-     * <h3>Example Usage</h3>
-     * <pre>{@code
-     *   EventPublishingConfigurationPropertiesBeanPropertyChangedListener listener = ...;
-     *   if (listener.isBound()) {
-     *       // Property changes will now be published as events
-     *   }
-     * }</pre>
      *
      * @return {@code true} if initial binding is complete, {@code false} otherwise
      */

--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/EventPublishingConfigurationPropertiesBeanPropertyChangedListener.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/EventPublishingConfigurationPropertiesBeanPropertyChangedListener.java
@@ -101,10 +101,6 @@ public class EventPublishingConfigurationPropertiesBeanPropertyChangedListener i
     void initConfigurationPropertiesBeanContext(ConfigurationPropertyName name, Bindable<?> target, BindContext context) {
         ConfigurationPropertiesBeanContext configurationPropertiesBeanContext = getConfigurationPropertiesBeanContext(name, target, context);
         if (configurationPropertiesBeanContext == null) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("No ConfigurationPropertiesBeanContext was found[name : '{}' , target : {} , depth : {}]",
-                        name, target, context.getDepth());
-            }
             return;
         }
         if (isConfigurationPropertiesBean(context)) {
@@ -131,7 +127,15 @@ public class EventPublishingConfigurationPropertiesBeanPropertyChangedListener i
     private ConfigurationPropertiesBeanContext getConfigurationPropertiesBeanContext(ConfigurationPropertyName name,
                                                                                      Bindable<?> target, BindContext context) {
         String prefix = getPrefix(name, context);
-        return beanContexts.computeIfAbsent(prefix, p -> newConfigurationPropertiesBeanContext(target, p));
+        ConfigurationPropertiesBeanContext configurationPropertiesBeanContext = this.beanContexts.computeIfAbsent(prefix,
+                p -> newConfigurationPropertiesBeanContext(target, p));
+        if (configurationPropertiesBeanContext == null) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("No ConfigurationPropertiesBeanContext was found[name : '{}' , target : {} , depth : {}]",
+                        name, target, context.getDepth());
+            }
+        }
+        return configurationPropertiesBeanContext;
     }
 
     ConfigurationPropertiesBeanContext newConfigurationPropertiesBeanContext(Bindable<?> target, String prefix) {
@@ -170,6 +174,9 @@ public class EventPublishingConfigurationPropertiesBeanPropertyChangedListener i
         if (isBoundProperty(context)) {
             ConfigurationProperty property = context.getConfigurationProperty();
             ConfigurationPropertiesBeanContext configurationPropertiesBeanContext = getConfigurationPropertiesBeanContext(name, target, context);
+            if (configurationPropertiesBeanContext == null) {
+                return;
+            }
             configurationPropertiesBeanContext.setProperty(property, result, isBound());
             if (logger.isTraceEnabled()) {
                 logger.trace("binding Bean property is finished , configuration property : '{}' , type : '{}' , depth : {} , result : '{}'", property, target.getType(), context.getDepth(), result);

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/TestConfigurationProperties.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/TestConfigurationProperties.java
@@ -17,6 +17,7 @@
 
 package io.microsphere.spring.boot.context.properties;
 
+import org.springframework.boot.autoconfigure.info.ProjectInfoProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
@@ -39,6 +40,8 @@ public class TestConfigurationProperties {
     private String[] aliases;
 
     private List<Integer> ports;
+
+    private Map<String, List<ProjectInfoProperties>> projects;
 
     public String getName() {
         return name;
@@ -70,5 +73,13 @@ public class TestConfigurationProperties {
 
     public void setPorts(List<Integer> ports) {
         this.ports = ports;
+    }
+
+    public Map<String, List<ProjectInfoProperties>> getProjects() {
+        return projects;
+    }
+
+    public void setProjects(Map<String, List<ProjectInfoProperties>> projects) {
+        this.projects = projects;
     }
 }

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/TestConstructorBindingConfigurationProperties.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/TestConstructorBindingConfigurationProperties.java
@@ -18,6 +18,7 @@
 package io.microsphere.spring.boot.context.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 /**
  * {@link ConfigurationProperties @ConfigurationProperties} for testing
@@ -31,12 +32,32 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("test.constructor.binding")
 public class TestConstructorBindingConfigurationProperties {
 
-    private final String name;
+    private String name;
 
-    private final String value;
+    private String value;
 
+    @ConstructorBinding
     public TestConstructorBindingConfigurationProperties(String name, String value) {
         this.name = name;
+        this.value = value;
+    }
+
+    public TestConstructorBindingConfigurationProperties() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
         this.value = value;
     }
 }

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContextTest.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContextTest.java
@@ -62,17 +62,17 @@ public class ConfigurationPropertiesBeanContextTest {
         context.refresh();
         ConfigurationProperties annotation = beanInfo.getAnnotation();
         AnnotationAttributes annotationAttributes = getAnnotationAttributes(annotation);
-        this.beanContext = new ConfigurationPropertiesBeanContext(forRawClass(ServerProperties.class), annotationAttributes,
-                beanInfo.getPrefix(), context);
+        this.beanContext = new ConfigurationPropertiesBeanContext("server", forRawClass(ServerProperties.class),
+                annotationAttributes, context);
     }
 
     @Test
-    void testInitialize() {
+    void testSetBean() {
         ServerProperties serverProperties = new ServerProperties();
-        this.beanContext.initialize(serverProperties);
+        this.beanContext.setBean(serverProperties);
         assertNull(serverProperties.getPort());
 
-        this.beanContext.initialize(new JacksonProperties());
+        this.beanContext.setBean(new JacksonProperties());
     }
 
     @Test
@@ -83,20 +83,20 @@ public class ConfigurationPropertiesBeanContextTest {
         ConfigurationProperty property = newConfigurationProperty(propertyName, propertyValue);
 
         ServerProperties serverProperties = new ServerProperties();
-        this.beanContext.initialize(serverProperties);
+        this.beanContext.setBean(serverProperties);
 
-        this.beanContext.setProperty(property, propertyValue, false);
+        this.beanContext.setProperty(property, propertyValue);
 
         Bindable<String> bindable = ofInstance("Mercy");
-        this.beanContext.initProperty(property.getName(), bindable);
-        this.beanContext.setProperty(property, propertyValue, true);
-        this.beanContext.setProperty(property, propertyValue, true);
+        // this.beanContext.initProperty(property.getName(), bindable);
+        this.beanContext.setProperty(property, propertyValue);
+        this.beanContext.setProperty(property, propertyValue);
     }
 
     @Test
     void testGetPropertyValueOnFailed() {
         assertNull(this.beanContext.getPropertyValue("invalid.property.name"));
-        this.beanContext.initialize(new ServerProperties());
+        this.beanContext.setBean(new ServerProperties());
         assertNull(this.beanContext.getPropertyValue("invalid.property.name"));
     }
 

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/bind/EventPublishingConfigurationPropertiesBeanPropertyChangedListenerTest.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/bind/EventPublishingConfigurationPropertiesBeanPropertyChangedListenerTest.java
@@ -137,14 +137,14 @@ class EventPublishingConfigurationPropertiesBeanPropertyChangedListenerTest {
         }
 
         Map<String, String> properties = ofMap("key-1", "value-1", "key-2", "value-2", "key-3", "value-3");
-        assertEquals("test-name", testConfigurationProperties.getName());
-        assertEquals(properties, testConfigurationProperties.getProperties());
-        assertArrayEquals(ofArray("a", "b", "c"), testConfigurationProperties.getAliases());
-        assertEquals(ofList(7070, 8080, 9090), testConfigurationProperties.getPorts());
+        assertEquals("test-name", this.testConfigurationProperties.getName());
+        assertEquals(properties, this.testConfigurationProperties.getProperties());
+        assertArrayEquals(ofArray("a", "b", "c"), this.testConfigurationProperties.getAliases());
+        assertEquals(ofList(7070, 8080, 9090), this.testConfigurationProperties.getPorts());
 
         this.eventHolder.reset();
 
-        setProperty("test.properties.key-1", "value-x", testConfigurationProperties);
+        setProperty("test.properties.key-1", "value-x", this.testConfigurationProperties);
 
         ConfigurationPropertiesBeanPropertyChangedEvent event = this.eventHolder.getValue();
         assertSame(this.testConfigurationProperties, event.getSource());
@@ -153,6 +153,15 @@ class EventPublishingConfigurationPropertiesBeanPropertyChangedListenerTest {
         assertEquals(properties, event.getOldValue());
         assertEquals(ofMap("key-1", "value-x", "key-2", "value-2", "key-3", "value-3"), event.getNewValue());
 
+    }
+
+    @Test
+    void testTestConstructorBindingConfigurationProperties(int index) {
+        if (index > 0) {
+            return;
+        }
+        assertEquals("test-constructor-binding-name", this.testConstructorBindingConfigurationProperties.getName());
+        assertEquals("test-constructor-binding-value", this.testConstructorBindingConfigurationProperties.getValue());
     }
 
     void setProperty(String configurationPropertyName, String propertyValue, Object configurationPropertiesBean) {

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/bind/EventPublishingConfigurationPropertiesBeanPropertyChangedListenerTest.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/bind/EventPublishingConfigurationPropertiesBeanPropertyChangedListenerTest.java
@@ -18,6 +18,7 @@ package io.microsphere.spring.boot.context.properties.bind;
 
 import io.microsphere.spring.boot.context.properties.ListenableConfigurationPropertiesBindHandlerAdvisor;
 import io.microsphere.spring.boot.context.properties.TestConfigurationProperties;
+import io.microsphere.spring.boot.context.properties.TestConstructorBindingConfigurationProperties;
 import io.microsphere.spring.test.junit.jupiter.SpringLoggingTest;
 import io.microsphere.util.ValueHolder;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,7 +51,6 @@ import static io.microsphere.util.ArrayUtils.ofArray;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -78,12 +78,20 @@ import static org.springframework.boot.context.properties.source.ConfigurationPr
         "test.aliases[0]=a",
         "test.aliases[1]=b",
         "test.aliases[2]=c",
-        "test.ports=7070,8080,9090"
+        "test.ports=7070,8080,9090",
+        "test.projects.project-1[0].build.location=META-INF/build-info.properties",
+        "test.projects.project-1[1].build.encoding=UTF-8",
+        "test.projects.project-2[0].git.location=my-git.properties",
+
+        // TestConstructorBindingConfigurationProperties
+        "test.constructor.binding.name=test-constructor-binding-name",
+        "test.constructor.binding.value=test-constructor-binding-value",
 })
 @EnableAutoConfiguration
 @EnableConfigurationProperties(
         value = {
-                TestConfigurationProperties.class
+                TestConfigurationProperties.class,
+                TestConstructorBindingConfigurationProperties.class
         }
 )
 class EventPublishingConfigurationPropertiesBeanPropertyChangedListenerTest {
@@ -98,6 +106,9 @@ class EventPublishingConfigurationPropertiesBeanPropertyChangedListenerTest {
 
     @Autowired
     private TestConfigurationProperties testConfigurationProperties;
+
+    @Autowired
+    private TestConstructorBindingConfigurationProperties testConstructorBindingConfigurationProperties;
 
     @Autowired
     private EventPublishingConfigurationPropertiesBeanPropertyChangedListener listener;
@@ -166,10 +177,5 @@ class EventPublishingConfigurationPropertiesBeanPropertyChangedListenerTest {
         when(context.getDepth()).thenReturn(0);
 
         this.listener.initConfigurationPropertiesBeanContext(name, target, context);
-    }
-
-    @Test
-    void testNewConfigurationPropertiesBeanContextOnMissingConfigurationProperties() {
-        assertNull(this.listener.newConfigurationPropertiesBeanContext(of(String.class), "test"));
     }
 }

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/bind/util/BindUtilsTest.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/bind/util/BindUtilsTest.java
@@ -29,8 +29,6 @@ import org.springframework.mock.env.MockEnvironment;
 
 import java.util.Map;
 
-import static io.microsphere.spring.boot.SpringBootVersion.CURRENT;
-import static io.microsphere.spring.boot.SpringBootVersion.SPRING_BOOT_2_2_1;
 import static io.microsphere.spring.boot.context.properties.bind.ConfigurationPropertiesBeanContextTest.newConfigurationProperty;
 import static io.microsphere.spring.boot.context.properties.bind.util.BindUtils.bind;
 import static io.microsphere.spring.boot.context.properties.bind.util.BindUtils.getBindConstructor;
@@ -38,7 +36,6 @@ import static io.microsphere.spring.boot.context.properties.bind.util.BindUtils.
 import static io.microsphere.spring.boot.context.properties.bind.util.BindUtils.isConfigurationPropertiesBean;
 import static io.microsphere.spring.boot.util.TestUtils.assertServerPropertiesPort;
 import static io.microsphere.spring.core.env.EnvironmentUtils.getProperties;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -115,8 +112,8 @@ class BindUtilsTest {
         assertNull(getBindConstructor(of(ServerProperties.class), false));
         assertNull(getBindConstructor(of(ServerProperties.class), true));
 
-        assertEquals(CURRENT.lt(SPRING_BOOT_2_2_1), getBindConstructor(of(TestConstructorBindingConfigurationProperties.class), false) == null);
-        assertEquals(CURRENT.lt(SPRING_BOOT_2_2_1), getBindConstructor(of(TestConstructorBindingConfigurationProperties.class), true) == null);
+        assertNull(getBindConstructor(of(TestConstructorBindingConfigurationProperties.class), false));
+        assertNull(getBindConstructor(of(TestConstructorBindingConfigurationProperties.class), true));
     }
 
     @Test

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/source/util/ConfigurationPropertyUtilsTest.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/source/util/ConfigurationPropertyUtilsTest.java
@@ -42,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.boot.context.properties.bind.Bindable.ofInstance;
 import static org.springframework.boot.context.properties.source.ConfigurationPropertyName.EMPTY;
 import static org.springframework.boot.context.properties.source.ConfigurationPropertyName.of;
 
@@ -119,6 +120,12 @@ class ConfigurationPropertyUtilsTest {
             }
         });
         assertNotNull(serverProperties);
+    }
+
+    @Test
+    void testNewConfigurationPropertiesBeanPropertyOnNull() {
+        Bindable<String> bindable = ofInstance("test");
+        assertNull(newConfigurationPropertiesBeanProperty(bindable));
     }
 
     void assertToDashedForm(String name) {

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/source/util/ConfigurationPropertyUtilsTest.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/source/util/ConfigurationPropertyUtilsTest.java
@@ -62,10 +62,10 @@ class ConfigurationPropertyUtilsTest {
             @Override
             public void onSuccess(ConfigurationPropertyName name, Bindable<?> target, BindContext context, Object result) {
                 assertEquals(prefix, getPrefix(name, context));
-                assertEquals(prefix, ConfigurationPropertyUtils.getSource(name));
+                assertEquals(prefix, getSource(name));
             }
         });
-        assertEquals((Integer) 12345, serverProperties.getPort());
+        assertEquals(12345, serverProperties.getPort());
 
         BindContext context = mock(BindContext.class);
         when(context.getDepth()).thenReturn(1);

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.32</microsphere-spring.version>
+        <microsphere-spring.version>0.1.33</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.4</version>
+        <version>0.3.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request refactors and enhances the `ConfigurationPropertiesBeanContext` class, improving its encapsulation, property binding, and bean management. The changes introduce new utility methods, improve property value handling, and update the way beans and their properties are initialized and accessed. Additionally, the documentation is updated to reflect the latest versions.

**Enhancements to `ConfigurationPropertiesBeanContext`:**

* Added new fields and utility methods for better encapsulation, including `beanName`, `getBeanName()`, `getBeanType()`, `isConstructorBindingBean()`, `getPrefix()`, and `getBeanClass()`. [[1]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abR87-R94) [[2]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abR114-R191)
* Refactored bean initialization and property handling: initialization now retrieves the bean from the context if necessary, and property values are cloned for safety. [[1]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abL138-R201) [[2]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abL153-R217) [[3]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abL218-L223) [[4]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abL237-R346) [[5]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abL275-R378)
* Introduced methods to bind property values after binding (`bindPropertyValues`, `bindPropertyValue`), improving support for property updates.

**Code cleanup and imports:**

* Updated and added several imports to support new features and refactored code. [[1]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abR27-R31) [[2]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abL47-L64)

**Documentation updates:**

* Updated the `README.md` to reflect the latest released versions for both `main` and `1.x` branches.