### PR TITLE
Align bean class resolution with ResolvableType API

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Choose the version that matches your Spring Boot generation:
 
 | Branch | Spring Boot Compatibility | Latest Version |
 |--------|---------------------------|----------------|
-| `main` | 3.0.x – 3.5.x, 4.1.x      | `0.2.27`       |
-| `1.x`  | 2.0.x – 2.7.x             | `0.1.27`       |
+| `main` | 3.0.x – 3.5.x, 4.1.x      | `0.2.28`       |
+| `1.x`  | 2.0.x – 2.7.x             | `0.1.28`       |
 
 ### Add Module Dependencies
 

--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
@@ -176,7 +176,7 @@ class ConfigurationPropertiesBeanContext {
      */
     @Nonnull
     Class<?> getBeanClass() {
-        return getBeanType().getRawClass();
+        return getBeanType().resolve();
     }
 
     void initializeBean(Object bean) {
@@ -209,7 +209,7 @@ class ConfigurationPropertiesBeanContext {
     }
 
     private void initBeanProperties(ResolvableType beanType, ConfigurationPropertyName prefixName, String nestedPath) {
-        Class<?> beanClass = beanType.getRawClass();
+        Class<?> beanClass = beanType.resolve();
         if (isCandidateClass(beanClass)) {
             Constructor<?> bindConstructor = this.bindConstructor;
             if (bindConstructor == null) {

--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
@@ -544,8 +544,14 @@ class ConfigurationPropertiesBeanContext {
      * @return {@code true} if the property is a binding candidate, {@code false} otherwise
      */
     static boolean isCandidateProperty(PropertyDescriptor descriptor) {
+        if (descriptor == null) {
+            return false;
+        }
         Method readMethod = descriptor.getReadMethod();
-        return readMethod == null || !Object.class.equals(readMethod.getDeclaringClass());
+        if (readMethod == null) {
+            return false;
+        }
+        return !Object.class.equals(readMethod.getDeclaringClass());
     }
 
     /**
@@ -563,6 +569,9 @@ class ConfigurationPropertiesBeanContext {
      * @return {@code true} if the class is a binding candidate, {@code false} otherwise
      */
     static boolean isCandidateClass(Class<?> beanClass) {
+        if (beanClass == null) {
+            return false;
+        }
         if (isPrimitiveOrWrapper(beanClass) || beanClass.isEnum()) {
             return false;
         }

--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/EventPublishingConfigurationPropertiesBeanPropertyChangedListener.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/EventPublishingConfigurationPropertiesBeanPropertyChangedListener.java
@@ -50,8 +50,7 @@ import static io.microsphere.spring.context.ApplicationContextUtils.asConfigurab
  * @see ConfigurationPropertiesBeanPropertyChangedEvent
  * @since 1.0.0
  */
-public class EventPublishingConfigurationPropertiesBeanPropertyChangedListener implements BindListener,
-        ApplicationContextAware, InitializingBean, SmartInitializingSingleton {
+public class EventPublishingConfigurationPropertiesBeanPropertyChangedListener implements BindListener, ApplicationContextAware, InitializingBean, SmartInitializingSingleton {
 
     private static final Logger logger = getLogger(EventPublishingConfigurationPropertiesBeanPropertyChangedListener.class);
 

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContextTest.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContextTest.java
@@ -31,8 +31,10 @@ import org.springframework.core.ResolvableType;
 import org.springframework.core.annotation.AnnotationAttributes;
 
 import java.beans.PropertyDescriptor;
+import java.util.concurrent.TimeUnit;
 
 import static io.microsphere.spring.boot.context.properties.bind.ConfigurationPropertiesBeanContext.getInstance;
+import static io.microsphere.spring.boot.context.properties.bind.ConfigurationPropertiesBeanContext.isCandidateClass;
 import static io.microsphere.spring.boot.context.properties.bind.ConfigurationPropertiesBeanContext.isCandidateProperty;
 import static io.microsphere.spring.core.annotation.AnnotationUtils.getAnnotationAttributes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -144,11 +146,33 @@ public class ConfigurationPropertiesBeanContextTest {
 
     @Test
     void testIsCandidateProperty() {
+        assertFalse(isCandidateProperty(null));
         PropertyDescriptor descriptor = getPropertyDescriptor(ConfigurationPropertiesBeanContextTest.class, "name");
-        assertTrue(isCandidateProperty(descriptor));
+        assertFalse(isCandidateProperty(descriptor));
+
+        descriptor = getPropertyDescriptor(ConfigurationPropertiesBeanContextTest.class, "not-found");
+        assertFalse(isCandidateProperty(descriptor));
 
         descriptor = getPropertyDescriptor(ConfigurationPropertiesBeanContextTest.class, "class");
         assertFalse(isCandidateProperty(descriptor));
+
+        descriptor = getPropertyDescriptor(ServerProperties.class, "port");
+        assertTrue(isCandidateProperty(descriptor));
+    }
+
+    @Test
+    void testIsCandidateClass() {
+        // null
+        assertFalse(isCandidateClass(null));
+        // primitive type and wrapper type are not candidate class
+        assertFalse(isCandidateClass(int.class));
+        assertFalse(isCandidateClass(Integer.class));
+        // enumeration type
+        assertFalse(isCandidateClass(TimeUnit.class));
+        // String is candidate class,but is under java.lang package.
+        assertFalse(isCandidateClass(String.class));
+        // current class
+        assertTrue(isCandidateClass(getClass()));
     }
 
     public void setName(String name) {


### PR DESCRIPTION
This pull request makes a minor update to the way the bean class is resolved in the `ConfigurationPropertiesBeanContext` class. The change replaces the use of `getRawClass()` with `resolve()` when obtaining the underlying class from a `ResolvableType`, which can improve type resolution in certain scenarios.

- Use of `ResolvableType.resolve()` instead of `getRawClass()` to obtain the bean class in both the `getBeanClass()` method and the `initBeanProperties()` method in `ConfigurationPropertiesBeanContext`. [[1]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abL179-R179) [[2]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abL212-R212)