### PR TITLE
Add test module and actuator endpoint conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ Microsphere Spring Boot provides production-ready enhancements for Spring Boot a
 
 ### Prerequisites
 
-| Requirement | Version                                                             |
-|-------------|---------------------------------------------------------------------|
-| Java        | 17+                                                                 |
-| Maven       | 3.9+ (or use the included `mvnw` wrapper)                           |
-| Spring Boot | 3.0.x – 3.5.x, 4.0.x (`main` branch) / 2.0.x – 2.7.x (`1.x` branch) |
+| Requirement | Version                                                                     |
+|-------------|-----------------------------------------------------------------------------|
+| Java        | 17+                                                                         |
+| Maven       | 3.9+ (or use the included `mvnw` wrapper)                                   |
+| Spring Boot | 3.0.x – 3.5.x, 4.0.x - 4.1.x (`main` branch) / 2.0.x – 2.7.x (`1.x` branch) |
 
 ### Add the BOM
 
@@ -108,10 +108,10 @@ Import the Microsphere Spring Boot BOM into your `pom.xml` so all module version
 
 Choose the version that matches your Spring Boot generation:
 
-| Branch | Spring Boot Compatibility | Latest Version |
-|--------|---------------------------|----------------|
-| `main` | 3.0.x – 3.5.x, 4.1.x      | `0.2.29`       |
-| `1.x`  | 2.0.x – 2.7.x             | `0.1.29`       |
+| Branch | Spring Boot Compatibility    | Latest Version |
+|--------|------------------------------|----------------|
+| `main` | 3.0.x – 3.5.x, 4.0.x - 4.1.x | `0.2.29`       |
+| `1.x`  | 2.0.x – 2.7.x                | `0.1.29`       |
 
 ### Add Module Dependencies
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/microsphere-projects/microsphere-spring-boot)
 [![zread](https://img.shields.io/badge/Ask_Zread-_.svg?style=flat&color=00b0aa&labelColor=000000&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTQuOTYxNTYgMS42MDAxSDIuMjQxNTZDMS44ODgxIDEuNjAwMSAxLjYwMTU2IDEuODg2NjQgMS42MDE1NiAyLjI0MDFWNC45NjAxQzEuNjAxNTYgNS4zMTM1NiAxLjg4ODEgNS42MDAxIDIuMjQxNTYgNS42MDAxSDQuOTYxNTZDNS4zMTUwMiA1LjYwMDEgNS42MDE1NiA1LjMxMzU2IDUuNjAxNTYgNC45NjAxVjIuMjQwMUM1LjYwMTU2IDEuODg2NjQgNS4zMTUwMiAxLjYwMDEgNC45NjE1NiAxLjYwMDFaIiBmaWxsPSIjZmZmIi8%2BCjxwYXRoIGQ9Ik00Ljk2MTU2IDEwLjM5OTlIMi4yNDE1NkMxLjg4ODEgMTAuMzk5OSAxLjYwMTU2IDEwLjY4NjQgMS42MDE1NiAxMS4wMzk5VjEzLjc1OTlDMS42MDE1NiAxNC4xMTM0IDEuODg4MSAxNC4zOTk5IDIuMjQxNTYgMTQuMzk5OUg0Ljk2MTU2QzUuMzE1MDIgMTQuMzk5OSA1LjYwMTU2IDE0LjExMzQgNS42MDE1NiAxMy43NTk5VjExLjAzOTlDNS42MDE1NiAxMC42ODY0IDUuMzE1MDIgMTAuMzk5OSA0Ljk2MTU2IDEwLjM5OTlaIiBmaWxsPSIjZmZmIi8%2BCjxwYXRoIGQ9Ik0xMy43NTg0IDEuNjAwMUgxMS4wMzg0QzEwLjY4NSAxLjYwMDEgMTAuMzk4NCAxLjg4NjY0IDEwLjM5ODQgMi4yNDAxVjQuOTYwMUMxMC4zOTg0IDUuMzEzNTYgMTAuNjg1IDUuNjAwMSAxMS4wMzg0IDUuNjAwMUgxMy43NTg0QzE0LjExMTkgNS42MDAxIDE0LjM5ODQgNS4zMTM1NiAxNC4zOTg0IDQuOTYwMVYyLjI0MDFDMTQuMzk4NCAxLjg4NjY0IDE0LjExMTkgMS42MDAxIDEzLjc1ODQgMS42MDAxWiIgZmlsbD0iI2ZmZiIvPgo8cGF0aCBkPSJNNCAxMkwxMiA0TDQgMTJaIiBmaWxsPSIjZmZmIi8%2BCjxwYXRoIGQ9Ik00IDEyTDEyIDQiIHN0cm9rZT0iI2ZmZiIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgo8L3N2Zz4K&logoColor=ffffff)](https://zread.ai/microsphere-projects/microsphere-spring-boot)
 [![Maven Build](https://github.com/microsphere-projects/microsphere-spring-boot/actions/workflows/maven-build.yml/badge.svg)](https://github.com/microsphere-projects/microsphere-spring-boot/actions/workflows/maven-build.yml)
-[![Codecov](https://codecov.io/gh/microsphere-projects/microsphere-spring-boot/branch/main/graph/badge.svg)](https://app.codecov.io/gh/microsphere-projects/microsphere-spring-boot)
+[![Codecov](https://codecov.io/gh/microsphere-projects/microsphere-spring-boot/branch/dev-1.x/graph/badge.svg)](https://app.codecov.io/gh/microsphere-projects/microsphere-spring-boot)
 ![Maven](https://img.shields.io/maven-central/v/io.github.microsphere-projects/microsphere-spring-boot.svg)
 ![License](https://img.shields.io/github/license/microsphere-projects/microsphere-spring-boot.svg)
 
@@ -110,8 +110,8 @@ Choose the version that matches your Spring Boot generation:
 
 | Branch | Spring Boot Compatibility | Latest Version |
 |--------|---------------------------|----------------|
-| `main` | 3.0.x – 3.5.x, 4.1.x      | `0.2.28`       |
-| `1.x`  | 2.0.x – 2.7.x             | `0.1.28`       |
+| `main` | 3.0.x – 3.5.x, 4.1.x      | `0.2.29`       |
+| `1.x`  | 2.0.x – 2.7.x             | `0.1.29`       |
 
 ### Add Module Dependencies
 

--- a/microsphere-spring-boot-actuator/src/main/java/io/microsphere/spring/boot/actuate/condition/ConditionalOnActuatorEndpointPresent.java
+++ b/microsphere-spring-boot-actuator/src/main/java/io/microsphere/spring/boot/actuate/condition/ConditionalOnActuatorEndpointPresent.java
@@ -28,17 +28,17 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * {@link Conditional @Conditional} that checks whether the artifact "org.springframework.boot:spring-boot-configuration-processor"
- * is present
+ * {@link Conditional @Conditional} that checks whether the Spring Boot Actuator
+ * {@link org.springframework.boot.actuate.endpoint.annotation.Endpoint @Endpoint} API is present
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @see Conditional
- * @see org.springframework.boot.configurationprocessor.metadata.ConfigurationMetadata
+ * @see org.springframework.boot.actuate.endpoint.annotation.Endpoint
  * @since 1.0.0
  */
 @Target({TYPE, METHOD})
 @Retention(RUNTIME)
 @Documented
-@ConditionalOnClass(name = "org.springframework.boot.configurationprocessor.metadata.ConfigurationMetadata")
-public @interface ConditionalOnConfigurationProcessorPresent {
+@ConditionalOnClass(name = "org.springframework.boot.actuate.endpoint.annotation.Endpoint")
+public @interface ConditionalOnActuatorEndpointPresent {
 }

--- a/microsphere-spring-boot-compatible/src/main/java/org/springframework/boot/context/properties/ConstructorBinding.java
+++ b/microsphere-spring-boot-compatible/src/main/java/org/springframework/boot/context/properties/ConstructorBinding.java
@@ -36,10 +36,10 @@ import java.lang.annotation.Target;
  * {@link org.springframework.context.annotation.Import @Import}).
  *
  * @author Phillip Webb
- * @since 2.2.0
  * @see ConfigurationProperties
+ * @since 2.2.0
  */
-@Target({ ElementType.TYPE, ElementType.CONSTRUCTOR })
+@Target({ElementType.TYPE, ElementType.CONSTRUCTOR})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface ConstructorBinding {

--- a/microsphere-spring-boot-dependencies/pom.xml
+++ b/microsphere-spring-boot-dependencies/pom.xml
@@ -45,6 +45,12 @@
                 <version>${revision}</version>
             </dependency>
 
+            <dependency>
+                <groupId>io.github.microsphere-projects</groupId>
+                <artifactId>microsphere-spring-boot-test</artifactId>
+                <version>${revision}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 </project>

--- a/microsphere-spring-boot-test/pom.xml
+++ b/microsphere-spring-boot-test/pom.xml
@@ -89,8 +89,8 @@
 
         <!-- Servlet API -->
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/microsphere-spring-boot-test/pom.xml
+++ b/microsphere-spring-boot-test/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.github.microsphere-projects</groupId>
+        <artifactId>microsphere-spring-boot-parent</artifactId>
+        <version>${revision}</version>
+        <relativePath>../microsphere-spring-boot-parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.github.microsphere-projects</groupId>
+    <artifactId>microsphere-spring-boot-test</artifactId>
+    <version>${revision}</version>
+
+    <name>Microsphere :: Spring Boot :: Test</name>
+    <description>Microsphere Spring Boot Test</description>
+
+    <dependencies>
+
+        <!-- Microsphere Annotation Processor -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-annotation-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Microsphere Spring -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-spring-context</artifactId>
+        </dependency>
+
+        <!-- Microsphere Spring Test -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-spring-test</artifactId>
+        </dependency>
+
+        <!-- Spring Boot Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Spring Boot WebFlux -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Spring Boot Dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- JUnit -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Mockito -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- JSON Assert -->
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- hamcrest -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Servlet API -->
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- H2 -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Testing -->
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/microsphere-spring-boot-test/src/main/java/io/microsphere/spring/boot/test/AbstractAutoConfigurationTest.java
+++ b/microsphere-spring-boot-test/src/main/java/io/microsphere/spring/boot/test/AbstractAutoConfigurationTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.boot.test;
+
+import io.microsphere.annotation.Nonnull;
+import io.microsphere.spring.core.annotation.GenericAnnotationAttributes;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Set;
+
+import static io.microsphere.collection.SetUtils.newLinkedHashSet;
+import static io.microsphere.util.ArrayUtils.EMPTY_CLASS_ARRAY;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
+import static org.springframework.core.ResolvableType.forClass;
+
+/**
+ * Abstract class for auto-configuration class tests
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see AutoConfigurationTest
+ * @since 1.0.0
+ */
+public abstract class AbstractAutoConfigurationTest<A> {
+
+    /**
+     * The {@link Class class} of {@link SpringBootTest}
+     */
+    public static final Class<SpringBootTest> SPRING_BOOT_TEST_CLASS = SpringBootTest.class;
+
+    /**
+     * The {@link GenericAnnotationAttributes} of {@link SpringBootTest}
+     */
+    @Nonnull
+    protected final GenericAnnotationAttributes<SpringBootTest> springBootTestAttributes;
+
+    /**
+     * Is web application ?
+     */
+    protected final boolean isWebApplication;
+
+    /**
+     * The {@link Class class} of auto-configuration
+     */
+    @Nonnull
+    protected Class<A> autoConfigurationClass;
+
+    protected AbstractAutoConfigurationTest() {
+        Class<?> type = getClass();
+        SpringBootTest springBootTest = type.getAnnotation(SPRING_BOOT_TEST_CLASS);
+        assertNotNull(springBootTest, "The @SpringBootTest must not be annotated on " + type);
+        this.springBootTestAttributes = GenericAnnotationAttributes.of(springBootTest);
+        this.isWebApplication = !NONE.equals(springBootTestAttributes.get("webEnvironment"));
+        this.autoConfigurationClass = (Class<A>) forClass(getClass())
+                .as(AbstractAutoConfigurationTest.class).resolveGeneric(0);
+    }
+
+    @Test
+    protected abstract void testAutoConfiguredClasses();
+
+    @Test
+    protected abstract void testOnGlobalDisabledProperty();
+
+    @Test
+    protected abstract void testOnGlobalMissingClass();
+
+    @Nonnull
+    protected final String[] getPropertyValues() {
+        return this.springBootTestAttributes.getStringArray("properties");
+    }
+
+    @Nonnull
+    protected final Class<?>[] getAutoConfiguredClasses() {
+        Set<Class<?>> autoConfiguredClasses = newLinkedHashSet();
+        autoConfiguredClasses.add(this.autoConfigurationClass);
+        configureAutoConfiguredClasses(autoConfiguredClasses);
+        return autoConfiguredClasses.toArray(EMPTY_CLASS_ARRAY);
+    }
+
+    @Nonnull
+    protected final Set<String> getGlobalDisabledPropertyValues() {
+        Set<String> globalDisabledPropertyValues = newLinkedHashSet();
+        configureGlobalDisabledPropertyValues(globalDisabledPropertyValues);
+        return globalDisabledPropertyValues;
+    }
+
+    @Nonnull
+    protected final Set<Class<?>> getGlobalMissingClasses() {
+        Set<Class<?>> globalMissingClasses = newLinkedHashSet();
+        configureGlobalMissingClasses(globalMissingClasses);
+        return globalMissingClasses;
+    }
+
+    protected final Class<?>[] getClasses() {
+        return this.springBootTestAttributes.getClassArray("classes");
+    }
+
+    /**
+     * Configure auto-configured classes
+     *
+     * @param autoConfiguredClasses the auto-configured classes
+     */
+    protected abstract void configureAutoConfiguredClasses(Set<Class<?>> autoConfiguredClasses);
+
+    /**
+     * Configure global disabled property values
+     *
+     * @param globalDisabledPropertyValues the global disabled property values
+     */
+    protected abstract void configureGlobalDisabledPropertyValues(Set<String> globalDisabledPropertyValues);
+
+    /**
+     * Configure global missing classes
+     *
+     * @param globalMissingClasses the global missing classes
+     */
+    protected abstract void configureGlobalMissingClasses(Set<Class<?>> globalMissingClasses);
+}

--- a/microsphere-spring-boot-test/src/main/java/io/microsphere/spring/boot/test/AutoConfigurationTest.java
+++ b/microsphere-spring-boot-test/src/main/java/io/microsphere/spring/boot/test/AutoConfigurationTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.boot.test;
+
+import io.microsphere.annotation.Nonnull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.autoconfigure.AutoConfigurations.of;
+
+/**
+ * Abstract class for auto-configuration class tests
+ *
+ * @param <A> the type of auto-configuration class
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see ApplicationContextRunner
+ * @see SpringBootTest
+ * @since 1.0.0
+ */
+public abstract class AutoConfigurationTest<A> extends AbstractAutoConfigurationTest<A> {
+
+    @Nonnull
+    protected ApplicationContextRunner applicationContextRunner;
+
+    @BeforeEach
+    void setUp() {
+        String[] propertyValues = getPropertyValues();
+        Class<?>[] classes = getClasses();
+        this.applicationContextRunner = new ApplicationContextRunner()
+                .withPropertyValues(propertyValues)
+                .withConfiguration(of(this.autoConfigurationClass))
+                .withConfiguration(of(classes));
+    }
+
+    @Test
+    @Override
+    protected void testAutoConfiguredClasses() {
+        for (Class<?> autoConfiguredClass : getAutoConfiguredClasses()) {
+            assertAutoConfiguredClass(this.applicationContextRunner, autoConfiguredClass);
+        }
+    }
+
+    @Test
+    @Override
+    protected void testOnGlobalDisabledProperty() {
+        for (String propertyValue : getGlobalDisabledPropertyValues()) {
+            assertDisabledProperty(this.applicationContextRunner, propertyValue, getAutoConfiguredClasses());
+        }
+    }
+
+    @Test
+    @Override
+    protected void testOnGlobalMissingClass() {
+        for (Class<?> missingClass : getGlobalMissingClasses()) {
+            assertFilteredClass(this.applicationContextRunner, missingClass.getName(), getAutoConfiguredClasses());
+        }
+    }
+
+    public static void assertAutoConfiguredClass(ApplicationContextRunner runner, Class<?> autoConfiguredClass) {
+        runner.run(context -> assertThat(context).hasSingleBean(autoConfiguredClass));
+    }
+
+    public static void assertDisabledProperty(ApplicationContextRunner runner, String propertyValue, Class<?>... beanClasses) {
+        runner.withPropertyValues(propertyValue)
+                .run(context -> {
+                    for (Class<?> beanClass : beanClasses) {
+                        assertThat(context).doesNotHaveBean(beanClass);
+                    }
+                });
+    }
+
+    public static void assertFilteredClass(ApplicationContextRunner runner, String filteredClass, Class<?>... beanClasses) {
+        runner.withClassLoader(new FilteredClassLoader(filteredClass))
+                .run(context -> {
+                    for (Class<?> beanClass : beanClasses) {
+                        assertThat(context).doesNotHaveBean(beanClass);
+                    }
+                });
+    }
+}

--- a/microsphere-spring-boot-test/src/main/java/io/microsphere/spring/boot/test/WebAutoConfigurationTest.java
+++ b/microsphere-spring-boot-test/src/main/java/io/microsphere/spring/boot/test/WebAutoConfigurationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.boot.test;
+
+import io.microsphere.annotation.Nonnull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.autoconfigure.AutoConfigurations.of;
+
+/**
+ * Abstract class for auto-configuration class tests
+ *
+ * @param <A> the type of auto-configuration class
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see ApplicationContextRunner
+ * @see SpringBootTest
+ * @since 1.0.0
+ */
+public abstract class WebAutoConfigurationTest<A> extends AbstractAutoConfigurationTest<A> {
+
+    @Nonnull
+    protected WebApplicationContextRunner webApplicationContextRunner;
+
+    protected WebAutoConfigurationTest() {
+        super();
+    }
+
+    @BeforeEach
+    void setUp() {
+        String[] propertyValues = getPropertyValues();
+        Class<?>[] classes = getClasses();
+        this.webApplicationContextRunner = new WebApplicationContextRunner()
+                .withSystemProperties(propertyValues)
+                .withConfiguration(of(this.autoConfigurationClass))
+                .withConfiguration(of(classes));
+    }
+
+    @Test
+    @Override
+    protected void testAutoConfiguredClasses() {
+        for (Class<?> autoConfiguredClass : getAutoConfiguredClasses()) {
+            assertAutoConfiguredClass(this.webApplicationContextRunner, autoConfiguredClass);
+        }
+    }
+
+    @Test
+    @Override
+    protected void testOnGlobalDisabledProperty() {
+        for (String propertyValue : getGlobalDisabledPropertyValues()) {
+            assertDisabledProperty(this.webApplicationContextRunner, propertyValue, getAutoConfiguredClasses());
+        }
+    }
+
+    @Test
+    @Override
+    protected void testOnGlobalMissingClass() {
+        for (Class<?> missingClass : getGlobalMissingClasses()) {
+            assertFilteredClass(this.webApplicationContextRunner, missingClass.getName(), getAutoConfiguredClasses());
+        }
+    }
+
+    public static void assertAutoConfiguredClass(WebApplicationContextRunner runner, Class<?> autoConfiguredClass) {
+        runner.run(context -> assertThat(context).hasSingleBean(autoConfiguredClass));
+    }
+
+    public static void assertDisabledProperty(WebApplicationContextRunner runner, String propertyValue, Class<?>... beanClasses) {
+        runner.withPropertyValues(propertyValue)
+                .run(context -> {
+                    for (Class<?> beanClass : beanClasses) {
+                        assertThat(context).doesNotHaveBean(beanClass);
+                    }
+                });
+    }
+
+    public static void assertFilteredClass(WebApplicationContextRunner runner, String filteredClass, Class<?>... beanClasses) {
+        runner.withClassLoader(new FilteredClassLoader(filteredClass))
+                .run(context -> {
+                    for (Class<?> beanClass : beanClasses) {
+                        assertThat(context).doesNotHaveBean(beanClass);
+                    }
+                });
+    }
+}

--- a/microsphere-spring-boot-test/src/test/java/io/microsphere/spring/boot/test/HttpAutoConfiguration.java
+++ b/microsphere-spring-boot-test/src/test/java/io/microsphere/spring/boot/test/HttpAutoConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.boot.test;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type.SERVLET;
+
+/**
+ * HTTP Auto-Configuration for Spring Boot Test
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see ConditionalOnWebApplication
+ * @since 1.0.0
+ */
+@ConditionalOnWebApplication(type = SERVLET)
+@ConditionalOnClass(CharacterEncodingFilter.class)
+@ConditionalOnProperty(name = "server.http.enabled", matchIfMissing = true)
+@Import(CharacterEncodingFilter.class)
+public class HttpAutoConfiguration {
+}

--- a/microsphere-spring-boot-test/src/test/java/io/microsphere/spring/boot/test/HttpAutoConfigurationTest.java
+++ b/microsphere-spring-boot-test/src/test/java/io/microsphere/spring/boot/test/HttpAutoConfigurationTest.java
@@ -17,23 +17,19 @@
 
 package io.microsphere.spring.boot.test;
 
-import org.springframework.boot.autoconfigure.web.servlet.HttpEncodingAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.util.Set;
 
 /**
- * {@link AutoConfigurationTest} Test for {@link HttpEncodingAutoConfiguration}
+ * {@link AutoConfigurationTest} Test for {@link HttpAutoConfiguration}
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
- * @see HttpEncodingAutoConfiguration
  * @since 1.0.0
  */
-@SpringBootTest(classes = {
-        HttpEncodingAutoConfigurationTest.class
-})
-public class HttpEncodingAutoConfigurationTest extends WebAutoConfigurationTest<HttpEncodingAutoConfiguration> {
+@SpringBootTest(classes = HttpAutoConfigurationTest.class)
+public class HttpAutoConfigurationTest extends WebAutoConfigurationTest<HttpAutoConfiguration> {
 
     @Override
     protected void configureAutoConfiguredClasses(Set<Class<?>> autoConfiguredClasses) {
@@ -42,7 +38,7 @@ public class HttpEncodingAutoConfigurationTest extends WebAutoConfigurationTest<
 
     @Override
     protected void configureGlobalDisabledPropertyValues(Set<String> globalDisabledPropertyValues) {
-        globalDisabledPropertyValues.add("server.servlet.encoding.enabled=false");
+        globalDisabledPropertyValues.add("server.http.enabled=false");
     }
 
     @Override

--- a/microsphere-spring-boot-test/src/test/java/io/microsphere/spring/boot/test/HttpEncodingAutoConfigurationTest.java
+++ b/microsphere-spring-boot-test/src/test/java/io/microsphere/spring/boot/test/HttpEncodingAutoConfigurationTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.boot.test;
+
+import org.springframework.boot.autoconfigure.web.servlet.HttpEncodingAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.util.Set;
+
+/**
+ * {@link AutoConfigurationTest} Test for {@link HttpEncodingAutoConfiguration}
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see HttpEncodingAutoConfiguration
+ * @since 1.0.0
+ */
+@SpringBootTest(classes = {
+        HttpEncodingAutoConfigurationTest.class
+})
+public class HttpEncodingAutoConfigurationTest extends WebAutoConfigurationTest<HttpEncodingAutoConfiguration> {
+
+    @Override
+    protected void configureAutoConfiguredClasses(Set<Class<?>> autoConfiguredClasses) {
+        autoConfiguredClasses.add(CharacterEncodingFilter.class);
+    }
+
+    @Override
+    protected void configureGlobalDisabledPropertyValues(Set<String> globalDisabledPropertyValues) {
+        globalDisabledPropertyValues.add("server.servlet.encoding.enabled=false");
+    }
+
+    @Override
+    protected void configureGlobalMissingClasses(Set<Class<?>> globalMissingClasses) {
+        globalMissingClasses.add(CharacterEncodingFilter.class);
+    }
+}

--- a/microsphere-spring-boot-test/src/test/java/io/microsphere/spring/boot/test/JmxAutoConfigurationTest.java
+++ b/microsphere-spring-boot-test/src/test/java/io/microsphere/spring/boot/test/JmxAutoConfigurationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.boot.test;
+
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jmx.export.MBeanExporter;
+
+import java.util.Set;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
+
+/**
+ * {@link AutoConfigurationTest} for {@link JmxAutoConfiguration}
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see AutoConfigurationTest
+ * @see JmxAutoConfiguration
+ * @since 1.0.0
+ */
+@SpringBootTest(classes = {
+        JmxAutoConfigurationTest.class
+}, webEnvironment = NONE,
+        properties = {
+                "spring.jmx.enabled=true"
+        })
+public class JmxAutoConfigurationTest extends AutoConfigurationTest<JmxAutoConfiguration> {
+
+    @Override
+    protected void configureAutoConfiguredClasses(Set<Class<?>> autoConfiguredClasses) {
+    }
+
+    @Override
+    protected void configureGlobalDisabledPropertyValues(Set<String> globalDisabledPropertyValues) {
+        globalDisabledPropertyValues.add("spring.jmx.enabled=false");
+    }
+
+    @Override
+    protected void configureGlobalMissingClasses(Set<Class<?>> globalMissingClasses) {
+        globalMissingClasses.add(MBeanExporter.class);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <module>microsphere-spring-boot-parent</module>
         <module>microsphere-spring-boot-dependencies</module>
         <module>microsphere-spring-boot-compatible</module>
+        <module>microsphere-spring-boot-test</module>
         <module>microsphere-spring-boot-core</module>
         <module>microsphere-spring-boot-webmvc</module>
         <module>microsphere-spring-boot-webflux</module>


### PR DESCRIPTION
This pull request introduces a new module for Spring Boot testing utilities, updates documentation and dependency management, and adds a new conditional annotation for actuator endpoints. The most significant changes are the addition of the `microsphere-spring-boot-test` module with abstract base classes to simplify and standardize auto-configuration testing, and the integration of this module into the dependency management. There are also minor documentation updates and an enhancement to an existing annotation.

**New Testing Module and Utilities:**

* Added new Maven module `microsphere-spring-boot-test` with its own `pom.xml`, providing dependencies and setup for Spring Boot testing, including support for JUnit, Mockito, Spring Boot Test, and more.
* Introduced `AbstractAutoConfigurationTest`, `AutoConfigurationTest`, and `WebAutoConfigurationTest` base classes in the new testing module, offering reusable patterns for testing Spring Boot auto-configurations in both standard and web contexts. [[1]](diffhunk://#diff-aba941abb4eb33c4ad7d5b6ff85f0d4d5577cedca4ee1a4be791c022d03283dfR1-R134) [[2]](diffhunk://#diff-a48bf5dbfc147da49fb73c8c6352f85edf6a4e3ad2e15539c43dffa55469a4ebR1-R99) [[3]](diffhunk://#diff-253d1fac1106b38520d0eeaafc449c5420c6c4d10ca75713d1599a1b25461fc3R1-R104)

**Dependency Management:**

* Registered the new `microsphere-spring-boot-test` module in `microsphere-spring-boot-dependencies/pom.xml`, making it available for dependency management across the project.

**Conditional Annotation Enhancement:**

* Added new annotation `ConditionalOnActuatorEndpointPresent` to easily conditionally enable beans based on the presence of Spring Boot Actuator endpoints.
* Enhanced Javadoc for `ConditionalOnConfigurationProcessorPresent` to reference the relevant Spring Boot configuration metadata class.

**Documentation Updates:**

* Updated `README.md` to reflect new branch coverage badges and the latest released versions for both `main` and `1.x` branches. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R114)