### PR TITLE
Update Maven parent POM and module versions to latest releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Choose the version that matches your Spring Boot generation:
 
 | Branch | Spring Boot Compatibility    | Latest Version |
 |--------|------------------------------|----------------|
-| `main` | 3.0.x – 3.5.x, 4.0.x - 4.1.x | `0.2.29`       |
-| `1.x`  | 2.0.x – 2.7.x                | `0.1.29`       |
+| `main` | 3.0.x – 3.5.x, 4.0.x - 4.1.x | `0.2.30`       |
+| `1.x`  | 2.0.x – 2.7.x                | `0.1.30`       |
 
 ### Add Module Dependencies
 

--- a/microsphere-spring-boot-actuator/pom.xml
+++ b/microsphere-spring-boot-actuator/pom.xml
@@ -65,9 +65,18 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Spring Boot Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Microsphere Spring Boot Test -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-spring-boot-test</artifactId>
+            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
 

--- a/microsphere-spring-boot-actuator/src/main/java/io/microsphere/spring/boot/actuate/autoconfigure/ActuatorEndpointsAutoConfiguration.java
+++ b/microsphere-spring-boot-actuator/src/main/java/io/microsphere/spring/boot/actuate/autoconfigure/ActuatorEndpointsAutoConfiguration.java
@@ -16,6 +16,7 @@
  */
 package io.microsphere.spring.boot.actuate.autoconfigure;
 
+import io.microsphere.spring.boot.actuate.condition.ConditionalOnActuatorEndpointPresent;
 import io.microsphere.spring.boot.actuate.condition.ConditionalOnConfigurationProcessorPresent;
 import io.microsphere.spring.boot.actuate.endpoint.ArtifactsEndpoint;
 import io.microsphere.spring.boot.actuate.endpoint.ConfigurationMetadataEndpoint;
@@ -40,9 +41,7 @@ import org.springframework.context.annotation.Import;
  * @see Endpoint
  * @since 1.0.0
  */
-@ConditionalOnClass(name = {
-        "org.springframework.boot.actuate.endpoint.annotation.Endpoint"
-})
+@ConditionalOnActuatorEndpointPresent
 @Import(value = {ActuatorEndpointsAutoConfiguration.ConfigurationProcessorConfiguration.class})
 public class ActuatorEndpointsAutoConfiguration implements BeanClassLoaderAware {
 

--- a/microsphere-spring-boot-core/pom.xml
+++ b/microsphere-spring-boot-core/pom.xml
@@ -18,18 +18,21 @@
     <description>Microsphere Spring Boot Core</description>
 
     <dependencies>
-        <!-- Microsphere Java -->
-        <dependency>
-            <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-java-core</artifactId>
-        </dependency>
 
+        <!-- Microsphere Annotation Processor -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-annotation-processor</artifactId>
             <optional>true</optional>
         </dependency>
 
+        <!-- Microsphere Java -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-java-core</artifactId>
+        </dependency>
+
+        <!-- Microsphere Spring Context -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-spring-context</artifactId>
@@ -55,16 +58,18 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Spring Boot Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
 
-        <!-- Microsphere Spring Test -->
+        <!-- Microsphere Spring Boot Test -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-spring-test</artifactId>
+            <artifactId>microsphere-spring-boot-test</artifactId>
+            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
 

--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/autoconfigure/ConfigurationPropertiesAutoConfiguration.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/autoconfigure/ConfigurationPropertiesAutoConfiguration.java
@@ -33,10 +33,10 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
  * @since 1.0.0
  */
 @ConditionalOnClass(name = {
-        "io.microsphere.spring.context.annotation.BeanCapableImportCandidate"
+        "io.microsphere.spring.context.annotation.BeanCapableImportCandidate"                      // Microsphere Spring Context API
 })
 @AutoConfigureBefore(name = {
-        "org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration"
+        "org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration"  // Spring Boot API
 })
 @EnableConfigurationPropertiesExtension
 public class ConfigurationPropertiesAutoConfiguration {

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/autoconfigure/ConfigurationPropertiesAutoConfigurationTest.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/context/autoconfigure/ConfigurationPropertiesAutoConfigurationTest.java
@@ -22,14 +22,13 @@ import io.microsphere.spring.boot.context.properties.ListenableConfigurationProp
 import io.microsphere.spring.boot.context.properties.TestConfigurationPropertiesBindHandlerAdvisor;
 import io.microsphere.spring.boot.context.properties.bind.EventPublishingConfigurationPropertiesBeanPropertyChangedListener;
 import io.microsphere.spring.boot.context.properties.bind.TestBindListener;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import io.microsphere.spring.boot.test.AutoConfigurationTest;
+import io.microsphere.spring.context.annotation.BeanCapableImportCandidate;
+import org.springframework.boot.test.context.SpringBootTest;
 
-import static io.microsphere.spring.beans.BeanUtils.isBeanPresent;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Set;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 /**
  * {@link ConfigurationPropertiesAutoConfiguration} Test
@@ -38,18 +37,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @see ConfigurationPropertiesAutoConfiguration
  * @since 1.0.0
  */
-@SpringJUnitConfig
-@EnableAutoConfiguration
-class ConfigurationPropertiesAutoConfigurationTest {
+@SpringBootTest(
+        classes = ConfigurationPropertiesAutoConfigurationTest.class,
+        webEnvironment = NONE
+)
+class ConfigurationPropertiesAutoConfigurationTest extends AutoConfigurationTest<ConfigurationPropertiesAutoConfiguration> {
 
-    @Autowired
-    private ConfigurableApplicationContext context;
+    @Override
+    protected void configureAutoConfiguredClasses(Set<Class<?>> autoConfiguredClasses) {
+        autoConfiguredClasses.add(ListenableConfigurationPropertiesBindHandlerAdvisor.class);
+        autoConfiguredClasses.add(EventPublishingConfigurationPropertiesBeanPropertyChangedListener.class);
+        autoConfiguredClasses.add(TestBindListener.class);
+        autoConfiguredClasses.add(TestConfigurationPropertiesBindHandlerAdvisor.class);
+    }
 
-    @Test
-    void test() {
-        assertTrue(isBeanPresent(this.context, ListenableConfigurationPropertiesBindHandlerAdvisor.class));
-        assertTrue(isBeanPresent(this.context, EventPublishingConfigurationPropertiesBeanPropertyChangedListener.class));
-        assertTrue(isBeanPresent(this.context, TestBindListener.class));
-        assertTrue(isBeanPresent(this.context, TestConfigurationPropertiesBindHandlerAdvisor.class));
+    @Override
+    protected void configureGlobalDisabledPropertyValues(Set<String> globalDisabledPropertyValues) {
+    }
+
+    @Override
+    protected void configureGlobalMissingClasses(Set<Class<?>> globalMissingClasses) {
+        globalMissingClasses.add(BeanCapableImportCandidate.class);
     }
 }

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.34</microsphere-spring.version>
+        <microsphere-spring.version>0.1.35</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.33</microsphere-spring.version>
+        <microsphere-spring.version>0.1.34</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/microsphere-spring-boot-webflux/pom.xml
+++ b/microsphere-spring-boot-webflux/pom.xml
@@ -20,18 +20,18 @@
 
     <dependencies>
 
-        <!-- Microsphere Spring Boot -->
-        <dependency>
-            <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-spring-boot-core</artifactId>
-            <version>${revision}</version>
-        </dependency>
-
         <!-- Microsphere Annotation Processor -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-annotation-processor</artifactId>
             <optional>true</optional>
+        </dependency>
+
+        <!-- Microsphere Spring Boot -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-spring-boot-core</artifactId>
+            <version>${revision}</version>
         </dependency>
 
         <!-- Microsphere Spring WebFlux -->
@@ -67,10 +67,11 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Microsphere Spring Test -->
+        <!-- Microsphere Spring Boot Test -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-spring-test</artifactId>
+            <artifactId>microsphere-spring-boot-test</artifactId>
+            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
 

--- a/microsphere-spring-boot-webflux/src/main/java/io/microsphere/spring/boot/webflux/autoconfigure/WebFluxAutoConfiguration.java
+++ b/microsphere-spring-boot-webflux/src/main/java/io/microsphere/spring/boot/webflux/autoconfigure/WebFluxAutoConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
  */
 @ConditionalOnWebFluxAvailable
 @AutoConfigureAfter(name = {
-        "org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration"
+        "org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration"  // Spring Boot API
 })
 @EnableWebFluxExtension(reversedProxyHandlerMapping = true)
 public class WebFluxAutoConfiguration {

--- a/microsphere-spring-boot-webmvc/pom.xml
+++ b/microsphere-spring-boot-webmvc/pom.xml
@@ -20,18 +20,18 @@
 
     <dependencies>
 
-        <!-- Microsphere Spring Boot -->
-        <dependency>
-            <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-spring-boot-core</artifactId>
-            <version>${revision}</version>
-        </dependency>
-
         <!-- Microsphere Annotation Processor -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-annotation-processor</artifactId>
             <optional>true</optional>
+        </dependency>
+
+        <!-- Microsphere Spring Boot -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-spring-boot-core</artifactId>
+            <version>${revision}</version>
         </dependency>
 
         <!-- Microsphere Spring Web MVC -->
@@ -79,10 +79,18 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Microsphere Spring Test -->
+        <!-- Microsphere Spring Boot Test -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-spring-test</artifactId>
+            <artifactId>microsphere-spring-boot-test</artifactId>
+            <version>${revision}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/microsphere-spring-boot-webmvc/src/main/java/io/microsphere/spring/boot/webmvc/autoconfigure/WebMvcAutoConfiguration.java
+++ b/microsphere-spring-boot-webmvc/src/main/java/io/microsphere/spring/boot/webmvc/autoconfigure/WebMvcAutoConfiguration.java
@@ -43,7 +43,7 @@ import static io.microsphere.spring.webmvc.context.ExclusiveViewResolverApplicat
  * @since 1.0.0
  */
 @ConditionalOnWebMvcAvailable
-@AutoConfigureAfter(name = "org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration")
+@AutoConfigureAfter(name = "org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration") // Spring Boot API
 @EnableWebMvcExtension(
         registerHandlerInterceptors = true,
         reversedProxyHandlerMapping = true

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.7</version>
+        <version>0.3.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.5</version>
+        <version>0.3.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.6</version>
+        <version>0.3.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request updates version numbers across the project to keep dependencies and documentation in sync with the latest releases.

Dependency and parent version updates:

* Updated the `microsphere-spring.version` property in `microsphere-spring-boot-parent/pom.xml` from `0.1.33` to `0.1.34` to use the latest Microsphere Spring release.
* Updated the parent project version in `pom.xml` from `0.3.5` to `0.3.8` to align with the latest build configuration.

Documentation updates:

* Updated the Spring Boot compatibility table in `README.md` to reflect the latest released versions: `main` branch to `0.2.30` and `1.x` branch to `0.1.30`.