### PR TITLE
Remove unused dependency and update version compatibility in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Choose the version that matches your Spring Boot generation:
 
 | Branch | Spring Boot Compatibility    | Latest Version |
 |--------|------------------------------|----------------|
-| `main` | 3.0.x – 3.5.x, 4.0.x - 4.1.x | `0.2.31`       |
-| `1.x`  | 2.0.x – 2.7.x                | `0.1.31`       |
+| `main` | 3.0.x – 3.5.x, 4.0.x - 4.1.x | `0.2.32`       |
+| `1.x`  | 2.0.x – 2.7.x                | `0.1.32`       |
 
 ### Add Module Dependencies
 

--- a/microsphere-spring-boot-core/pom.xml
+++ b/microsphere-spring-boot-core/pom.xml
@@ -26,12 +26,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Microsphere Java Core -->
-        <dependency>
-            <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-java-core</artifactId>
-        </dependency>
-
         <!-- Microsphere Spring Context -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
@@ -57,7 +51,7 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Testing Dependencies -->
+        <!-- Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.35</microsphere-spring.version>
+        <microsphere-spring.version>0.1.36</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>


### PR DESCRIPTION
This pull request primarily updates dependency versions and makes minor cleanup changes to the build files. The most important changes are:

Dependency version updates:
* Updated the `microsphere-spring.version` property in `microsphere-spring-boot-parent/pom.xml` from `0.1.35` to `0.1.36`.
* Updated the latest module versions in the compatibility table in `README.md` (`main` to `0.2.32`, `1.x` to `0.1.32`).

Build file cleanup:
* Removed the unnecessary dependency on `microsphere-java-core` from `microsphere-spring-boot-core/pom.xml`.
* Minor comment change in `microsphere-spring-boot-core/pom.xml` to clarify the testing dependencies section.