### PR TITLE
Update POM for microsphere dependencies and improve reflection usage

### DIFF
--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/bind/ConfigurationPropertiesBeanContext.java
@@ -49,7 +49,7 @@ import static io.microsphere.constants.SymbolConstants.DOT_CHAR;
 import static io.microsphere.lang.function.ThrowableSupplier.execute;
 import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.reflect.FieldUtils.findAllDeclaredFields;
-import static io.microsphere.reflect.FieldUtils.findField;
+import static io.microsphere.reflect.FieldUtils.getFieldValue;
 import static io.microsphere.reflect.MethodUtils.invokeMethod;
 import static io.microsphere.spring.beans.factory.config.BeanDefinitionUtils.getResolvableType;
 import static io.microsphere.spring.boot.context.properties.bind.util.BindUtils.getBindConstructor;
@@ -370,7 +370,7 @@ class ConfigurationPropertiesBeanContext {
         if (instance == null) {
             return null;
         }
-        return getFieldValue(instance, field);
+        return getFieldValue(true, instance, field);
     }
 
     ConfigurationPropertiesBeanProperty getProperty(ConfigurationPropertyName propertyName) {
@@ -431,7 +431,7 @@ class ConfigurationPropertiesBeanContext {
      */
     static Object clone(Object value) {
         if (value instanceof Cloneable) {
-            value = invokeMethod(value, "clone");
+            value = invokeMethod(true, value, "clone");
         }
         return value;
     }
@@ -500,30 +500,15 @@ class ConfigurationPropertiesBeanContext {
         }
         int index = nestedPath.indexOf(DOT_CHAR);
         if (index == -1) {
-            return getFieldValue(bean, nestedPath);
+            return getFieldValue(true, bean, nestedPath);
         }
         String fieldName = nestedPath.substring(0, index);
-        Object instance = getFieldValue(bean, fieldName);
+        Object instance = getFieldValue(true, bean, fieldName);
         if (instance == null) {
             return null;
         }
         String subNestedPath = nestedPath.substring(index + 1);
-        return getFieldValue(instance, subNestedPath);
-    }
-
-    static Object getFieldValue(Object instance, String fieldName) {
-        Field field = findField(instance, fieldName);
-        return getFieldValue(instance, field);
-    }
-
-    static Object getFieldValue(Object instance, Field field) {
-        Object fieldValue = FieldUtils.getFieldValue(instance, field);
-        if (fieldValue == null) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("The field['{}'] value can't be found in the instance : '{}'", field, instance);
-            }
-        }
-        return clone(fieldValue);
+        return getFieldValue(true, instance, subNestedPath);
     }
 
     static String buildPropertyPath(String propertyName, @Nullable String nestedPath) {

--- a/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/source/util/ConfigurationPropertyUtils.java
+++ b/microsphere-spring-boot-core/src/main/java/io/microsphere/spring/boot/context/properties/source/util/ConfigurationPropertyUtils.java
@@ -120,8 +120,8 @@ public abstract class ConfigurationPropertyUtils {
      */
     @Nonnull
     public static String getSource(ConfigurationPropertyName name) {
-        Object elements = getFieldValue(name, "elements");
-        return getFieldValue(elements, "source");
+        Object elements = getFieldValue(true, name, "elements");
+        return getFieldValue(true, elements, "source");
     }
 
     /**
@@ -203,12 +203,12 @@ public abstract class ConfigurationPropertyUtils {
         ConfigurationPropertiesBeanProperty property = new ConfigurationPropertiesBeanProperty();
 
         doWithFields(valueClass, valueField -> {
-            Object beanProperty = getFieldValue(value, valueField);
+            Object beanProperty = getFieldValue(true, value, valueField);
             if (beanProperty != null) {
                 doWithFields(BEAN_PROPERTY_CLASS, f -> {
-                    Object fieldValue = getFieldValue(beanProperty, f);
+                    Object fieldValue = getFieldValue(true, beanProperty, f);
                     Field targetField = findField(property, f.getName());
-                    setFieldValue(property, targetField, fieldValue);
+                    setFieldValue(true, property, targetField, fieldValue);
                 });
             }
         }, f -> BEAN_PROPERTY_CLASS.equals(f.getType()));

--- a/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/constants/SpringBootPropertyConstantsTest.java
+++ b/microsphere-spring-boot-core/src/test/java/io/microsphere/spring/boot/constants/SpringBootPropertyConstantsTest.java
@@ -39,7 +39,7 @@ class SpringBootPropertyConstantsTest {
         assertEquals("spring.autoconfigure.exclude", SPRING_AUTO_CONFIGURE_EXCLUDE_PROPERTY_NAME);
 
         assertEquals("configurationProperties", ATTACHED_PROPERTY_SOURCE_NAME);
-        assertEquals(getStaticFieldValue(ConfigurationPropertySources.class, "ATTACHED_PROPERTY_SOURCE_NAME"), ATTACHED_PROPERTY_SOURCE_NAME);
+        assertEquals(getStaticFieldValue(true, ConfigurationPropertySources.class, "ATTACHED_PROPERTY_SOURCE_NAME"), ATTACHED_PROPERTY_SOURCE_NAME);
     }
 
 }

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.36</microsphere-spring.version>
+        <microsphere-spring.version>0.1.37</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/microsphere-spring-boot-parent/pom.xml
+++ b/microsphere-spring-boot-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Boot Parent</description>
 
     <properties>
-        <microsphere-spring.version>0.1.37</microsphere-spring.version>
+        <microsphere-spring.version>0.1.38</microsphere-spring.version>
         <jolokia.version>1.7.2</jolokia.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/microsphere-spring-boot-test/src/main/java/io/microsphere/spring/boot/test/AbstractAutoConfigurationTest.java
+++ b/microsphere-spring-boot-test/src/main/java/io/microsphere/spring/boot/test/AbstractAutoConfigurationTest.java
@@ -31,9 +31,9 @@ import org.springframework.core.ResolvableType;
 import java.util.Set;
 
 import static io.microsphere.collection.SetUtils.newLinkedHashSet;
+import static io.microsphere.reflect.ConstructorUtils.newInstance;
 import static io.microsphere.text.FormatUtils.format;
 import static io.microsphere.util.ArrayUtils.EMPTY_CLASS_ARRAY;
-import static io.microsphere.util.ClassUtils.newInstance;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.8</version>
+        <version>0.3.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.10</version>
+        <version>0.3.11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request updates several methods to consistently use the new `getFieldValue` API with an explicit `forceAccess` boolean parameter, improving code clarity and access control for reflective field access. It also updates project dependencies and cleans up imports to align with these changes.

**Refactoring for field access and reflection:**

* Updated all usages of `getFieldValue` and related reflection utilities to use the new signature with a `forceAccess` boolean parameter, replacing the old method signatures throughout `ConfigurationPropertiesBeanContext.java` and `ConfigurationPropertyUtils.java`. This ensures explicit control over field accessibility and reduces ambiguity in reflection calls. [[1]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abL52-R52) [[2]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abL373-R373) [[3]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abL434-R434) [[4]](diffhunk://#diff-5da39f7fb0aeea5fa772e1368ac392d2808e1d87667ce9dc7620530dfbd9f3abL503-R511) [[5]](diffhunk://#diff-efe6869d5fc5d7416a7e2ae465d8061284a4ed323ee5ff6e4991193150af1971L123-R124) [[6]](diffhunk://#diff-efe6869d5fc5d7416a7e2ae465d8061284a4ed323ee5ff6e4991193150af1971L206-R211)

* Updated test and utility code to use the new `getStaticFieldValue` and `setFieldValue` signatures with the `forceAccess` parameter for consistency. [[1]](diffhunk://#diff-86f633ee894a21ffe452f5f3431bfbd776d213004e9ea2663cd783d3dfbe37c2L42-R42) [[2]](diffhunk://#diff-efe6869d5fc5d7416a7e2ae465d8061284a4ed323ee5ff6e4991193150af1971L206-R211)

**Dependency and import updates:**

* Bumped `microsphere-spring.version` to `0.1.38` in the parent POM and updated the build parent version to `0.3.11` for improved dependency management and latest features. [[1]](diffhunk://#diff-48d0b6c0dbb16ef27680cdee6f02093d1fb49923bc7627e84f042894d7817536L22-R22) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R8)

* Cleaned up imports in `AbstractAutoConfigurationTest.java` to use the correct `newInstance` utility from `ConstructorUtils`, reflecting the latest utility class organization.